### PR TITLE
Logo API and Profile related fixes

### DIFF
--- a/components/HeaderNav/HeaderNav.tsx
+++ b/components/HeaderNav/HeaderNav.tsx
@@ -27,7 +27,6 @@ export interface ProfileData {
     identity: Identity;
     accType: string;
   }
-
 }
 
 export interface Identity {
@@ -42,14 +41,30 @@ export interface Identity {
   businessName: string;
   businessType: string;
   businessLocation: string;
-  currCompanyTitle: string;
+  currTitle: string;
   currLocation?: string;
   funcExpertise: string;
   industryExpertise: string;
+  companyInfo?: CompanyInfo[];
 }
 
 export interface BasicProfile {
   name: string;
+}
+export interface Profile {
+    identity: Identity;
+    name: string;
+    accType: string;
+}
+
+export interface CompanyInfo {
+  companyName: string;
+  companyTitle: string;
+  companyImg: any;
+  companyStart: Date;
+  companyEnd: Date;
+  companyFunc: string;
+  companyIndustry: string;
 }
 
 const HamburgerItem = ({ children, isLast, to = '/' }) => {

--- a/components/Profile/CompanyModal/CompanyModal.tsx
+++ b/components/Profile/CompanyModal/CompanyModal.tsx
@@ -126,7 +126,6 @@ const CompanyModal = (props) => {
     const address = await connect(); // first address in the array
 
     if (address) {
-      // setShouldFetch(true);
       const ceramic = new CeramicClient(endpoint);      
       const threeIdConnect = new ThreeIdConnect();
       const provider = new EthereumAuthProvider(window.ethereum, address);
@@ -202,6 +201,8 @@ const CompanyModal = (props) => {
       if (evt.target.name == 'companyName') {
         setCompanyName(evt.target.value);
         setShouldFetch(true);
+      } else {
+        setShouldFetch(false);
       }
 
       if (evt.target.name == 'companyTitle') {
@@ -422,6 +423,7 @@ const CompanyModal = (props) => {
     )
   };
 
+ // Client-side data fetching for Clearbit's NameToDomain API (on company modal load)
  function CompanyInfoData(props) {
    console.log(props);
     const fetcher = (companyDomain: string,...args: Parameters<typeof fetch>) => fetch(companyDomain).then(response => response.json());

--- a/components/Profile/CompanyModal/CompanyModal.tsx
+++ b/components/Profile/CompanyModal/CompanyModal.tsx
@@ -92,14 +92,16 @@ const CompanyModal = (props) => {
     const [accType, setAccType] = useState(props.profileData.content.accType);
     const [identity, setIdentity] = useState(props.profileData.content.identity);
     const [profileData, setProfileData] = useState(props.profileData);
-    const [values, setValues] = useState({
-      companyName: props.profileData.content.identity.companyInfo[props.currCompany].companyName,
-      companyTitle: props.profileData.content.identity.companyInfo[props.currCompany].companyTitle,
-      companyStart: props.profileData.content.identity.companyInfo[props.currCompany].companyStart,
-      companyEnd: props.profileData.content.identity.companyInfo[props.currCompany].companyEnd,
-      companyFunc: props.profileData.content.identity.companyInfo[props.currCompany].companyFunc,
-      companyIndustry: props.profileData.content.identity.companyInfo[props.currCompany].companyIndustry
-  });
+    const emptyCompanyInfo = {
+      companyName: '',
+      companyTitle: '',
+      companyStart: '',
+      companyEnd: '',
+      companyFunc: '',
+      companyIndustry: '',
+    }
+
+    const companyInfo = props.profileData.content.identity.companyInfo && props.profileData.content.identity.companyInfo[props.currCompany] ? props.profileData.content.identity.companyInfo[props.currCompany]: emptyCompanyInfo;
 
     const [errors, setErrors] = useState({
       companyName: null,
@@ -110,6 +112,14 @@ const CompanyModal = (props) => {
       companyIndustry: null
     });
 
+    const [values, setValues] = useState({
+        companyName: companyInfo && companyInfo.companyName ? companyInfo.companyName: '',
+        companyTitle: companyInfo && companyInfo.companyTitle ? companyInfo.companyTitle: '',
+        companyStart: companyInfo && companyInfo.companyStart ? companyInfo.companyStart: '',
+        companyEnd: companyInfo && companyInfo.companyEnd ? companyInfo.companyEnd: '',
+        companyFunc: companyInfo && companyInfo.companyFunc ? companyInfo.companyFunc: '',
+        companyIndustry: companyInfo && companyInfo.companyIndustry ? companyInfo.companyIndustry: ''
+    });  
     
   async function updateCompanyInfo() {
     const address = await connect(); // first address in the array
@@ -256,139 +266,141 @@ const CompanyModal = (props) => {
 
     return (
       <>  
-        <Modal finalFocusRef={finalRef} isOpen={props.isOpen} onClose={props.onClose}>
+        <Modal finalFocusRef={finalRef} isOpen={props.isOpen} onClose={props.onClose} key={`companymodal--${props.currCompany}`}>
           <ModalOverlay />
           <ModalContent>
             <ModalHeader>Update your work experience</ModalHeader>
             <ModalCloseButton />
             <ModalBody>
-            <form style={{ alignSelf: "center"}}>
-                <FormControl p={2} id="company-name">
-                    <FormLabel>Company name</FormLabel>
-                    {shouldFetch && <CompanyInfoData companyName={companyName}/>}
-                    <Input required isInvalid={errors.companyName && (!props.profileData.content.identity.companyInfo[props.currCompany].companyName || !values.companyName)} errorBorderColor='red.300' placeholder="Company name" name="companyName" defaultValue={props.profileData.content.identity.companyInfo[props.currCompany].companyName || ''} onChange={handleChange}/>
-                    {errors.companyName && (!props.profileData.content.identity.companyInfo[props.currCompany].companyName || !values.companyName) && (
-                      <Text fontSize='xs' fontWeight='400' color='red.500'>{errors.companyName}</Text>
-                    )}
-                  </FormControl>
-                  <FormControl p={2} id="company-title">
-                    <FormLabel>Job title</FormLabel>
-                    <Input required isInvalid={errors.companyTitle && (!props.profileData.content.identity.companyInfo[props.currCompany].companyTitle || !values.companyTitle)} errorBorderColor='red.300' placeholder="Job title" name="companyTitle" defaultValue={props.profileData.content.identity.companyInfo[props.currCompany].companyTitle || ''} onChange={handleChange}/>
-                    {errors.companyTitle && (!props.profileData.content.identity.companyInfo[props.currCompany].companyTitle || !values.companyTitle) && (
-                      <Text fontSize='xs' fontWeight='400' color='red.500'>{errors.companyTitle}</Text>
-                    )}
-                  </FormControl>
-                  <FormControl p={2} id="company-start">
-                    <FormLabel>What was your start date?</FormLabel>
-                    <Input required isInvalid={errors.companyStart && (!props.profileData.content.identity.companyInfo[props.currCompany].companyStart || !values.companyStart)} errorBorderColor='red.300' name="companyStart" defaultValue={props.profileData.content.identity.companyInfo[props.currCompany].companyStart || ''} onChange={handleChange}/>
-                    {errors.companyStart && (!props.profileData.content.identity.companyInfo[props.currCompany].companyStart || !values.companyStart) && (
-                      <Text fontSize='xs' fontWeight='400' color='red.500'>{errors.companyStart}</Text>
-                    )}
-                  </FormControl>
-                  <FormControl p={2} id="company-end">
-                    <FormLabel>What was your end date?</FormLabel>
-                    <Input required isInvalid={errors.companyEnd && (!props.profileData.content.identity.companyInfo[props.currCompany].companyEnd || !values.companyEnd)} errorBorderColor='red.300' name="companyEnd" defaultValue={props.profileData.content.identity.companyInfo[props.currCompany].companyEnd || ''} onChange={handleChange}/>
-                    {errors.companyEnd && (!props.profileData.content.identity.companyInfo[props.currCompany].companyEnd || !values.companyEnd) && (
-                      <Text fontSize='xs' fontWeight='400' color='red.500'>{errors.companyEnd}</Text>
-                    )}
-                  </FormControl>
-                  <FormControl p={2} id="company-func">
-                    <FormLabel>Functional expertise</FormLabel>
-                    <Select required defaultValue={props.profileData.content.identity.companyInfo[props.currCompany].companyFunc} errorBorderColor='red.300' placeholder="Select functional expertise" name="funcExpertise" onChange={handleChange}>
-                          <option>Accounting</option>
-                          <option>Creative</option>
-                          <option>Audit</option>
-                          <option>Board & Advisory</option>
-                          <option>Corporate Development</option>
-                          <option>Comp & Benefits</option>
-                          <option>Compliance</option>
-                          <option>Management Consulting</option>
-                          <option>Data & Analytics</option>
-                          <option>Product Design</option>
-                          <option>Digital</option>
-                          <option>Engineering</option>
-                          <option>Entrepreneurship</option>
-                          <option>Finance</option>
-                          <option>General Management</option>
-                          <option>Human Resources</option>
-                          <option>IT Infrastructure</option>
-                          <option>Innovation</option>
-                          <option>Investor</option>
-                          <option>Legal</option>
-                          <option>Marketing</option>
-                          <option>Media & Comms</option>
-                          <option>Merchandising</option>
-                          <option>Security</option>
-                          <option>Operations</option>
-                          <option>Portfolio Operations</option>
-                          <option>Procurement</option>
-                          <option>Product Management</option>
-                          <option>Investor Relations</option>
-                          <option>Regulatory</option>
-                          <option>Research</option>
-                          <option>Risk</option>
-                          <option>Strategy</option>
-                          <option>Technology</option>
-                          <option>Transformation</option>
-                          <option>Sales & Customer</option>
-                          <option>Data Science</option>
-                          <option>Talent Acquisition</option>
-                          <option>Tax</option>
-                          <option>Cybersecurity</option>
-                          <option>Investment Banking</option>
-                          <option>Supply Chain</option>
-                        </Select>
-                  </FormControl>
-                  <FormControl p={2} id="company-industry">
-                    <FormLabel>Industry</FormLabel>
-                    <Select required defaultValue={props.profileData.content.identity.companyInfo[props.currCompany].companyIndustry} errorBorderColor='red.300' placeholder="Select industry expertise" name="industryExpertise" onChange={handleChange}>
-                          <option>Accounting</option>
-                          <option>Angel Investment</option>
-                          <option>Asset Management</option>
-                          <option>Auto Insurance</option>
-                          <option>Banking</option>
-                          <option>Bitcoin</option>
-                          <option>Commercial Insurance</option>
-                          <option>Commercial Lending</option>
-                          <option>Credit</option>
-                          <option>Credit Bureau</option>
-                          <option>Credit Cards</option>
-                          <option>Crowdfunding</option>
-                          <option>Cryptocurrency</option>
-                          <option>Debit Cards</option>
-                          <option>Debt Collections</option>
-                          <option>Finance</option>
-                          <option>Financial Exchanges</option>
-                          <option>Financial Services</option>
-                          <option>FinTech</option>
-                          <option>Fraud Detection</option>
-                          <option>Funding Platform</option>
-                          <option>Gift Card</option>
-                          <option>Health Insurance</option>
-                          <option>Hedge Funds</option>
-                          <option>Impact Investing</option>
-                          <option>Incubators</option>
-                          <option>Insurance</option>
-                          <option>InsurTech</option>
-                          <option>Leasing</option>
-                          <option>Lending</option>
-                          <option>Life Insurance</option>
-                          <option>Micro Lending</option>
-                          <option>Mobile Payments</option>
-                          <option>Payments</option>
-                          <option>Personal Finance</option>
-                          <option>Prediction Markets</option>
-                          <option>Property Insurance</option>
-                          <option>Real Estate Investment</option>
-                          <option>Stock Exchanges</option>
-                          <option>Trading Platform</option>
-                          <option>Transaction Processing</option>
-                          <option>Venture Capital</option>
-                          <option>Virtual Currency</option>
-                          <option>Wealth Management</option>
-                        </Select>
-                  </FormControl>
-            </form>
+              {companyInfo ? (
+                            <form style={{ alignSelf: "center"}}>
+                            <FormControl p={2} id="company-name">
+                                <FormLabel>Company name</FormLabel>
+                                {shouldFetch && <CompanyInfoData companyName={companyName}/>}
+                                <Input required isInvalid={errors.companyName && (!companyInfo.companyName || !values.companyName)} errorBorderColor='red.300' placeholder="Company name" name="companyName" defaultValue={companyInfo.companyName || ''} onChange={handleChange}/>
+                                {errors.companyName && (!companyInfo.companyName || !values.companyName) && (
+                                  <Text fontSize='xs' fontWeight='400' color='red.500'>{errors.companyName}</Text>
+                                )}
+                              </FormControl>
+                              <FormControl p={2} id="company-title">
+                                <FormLabel>Job title</FormLabel>
+                                <Input required isInvalid={errors.companyTitle && (!companyInfo.companyTitle || !values.companyTitle)} errorBorderColor='red.300' placeholder="Job title" name="companyTitle" defaultValue={companyInfo.companyTitle || ''} onChange={handleChange}/>
+                                {errors.companyTitle && (!companyInfo.companyTitle || !values.companyTitle) && (
+                                  <Text fontSize='xs' fontWeight='400' color='red.500'>{errors.companyTitle}</Text>
+                                )}
+                              </FormControl>
+                              <FormControl p={2} id="company-start">
+                                <FormLabel>What was your start date?</FormLabel>
+                                <Input required isInvalid={errors.companyStart && (!companyInfo.companyStart || !values.companyStart)} errorBorderColor='red.300' name="companyStart" defaultValue={companyInfo.companyStart || ''} onChange={handleChange}/>
+                                {errors.companyStart && (!companyInfo.companyStart || !values.companyStart) && (
+                                  <Text fontSize='xs' fontWeight='400' color='red.500'>{errors.companyStart}</Text>
+                                )}
+                              </FormControl>
+                              <FormControl p={2} id="company-end">
+                                <FormLabel>What was your end date?</FormLabel>
+                                <Input required isInvalid={errors.companyEnd && (!companyInfo.companyEnd || !values.companyEnd)} errorBorderColor='red.300' name="companyEnd" defaultValue={companyInfo.companyEnd || ''} onChange={handleChange}/>
+                                {errors.companyEnd && (!companyInfo.companyEnd || !values.companyEnd) && (
+                                  <Text fontSize='xs' fontWeight='400' color='red.500'>{errors.companyEnd}</Text>
+                                )}
+                              </FormControl>
+                              <FormControl p={2} id="company-func">
+                                <FormLabel>Functional expertise</FormLabel>
+                                <Select required defaultValue={companyInfo.companyFunc} errorBorderColor='red.300' placeholder="Select functional expertise" name="funcExpertise" onChange={handleChange}>
+                                      <option>Accounting</option>
+                                      <option>Creative</option>
+                                      <option>Audit</option>
+                                      <option>Board & Advisory</option>
+                                      <option>Corporate Development</option>
+                                      <option>Comp & Benefits</option>
+                                      <option>Compliance</option>
+                                      <option>Management Consulting</option>
+                                      <option>Data & Analytics</option>
+                                      <option>Product Design</option>
+                                      <option>Digital</option>
+                                      <option>Engineering</option>
+                                      <option>Entrepreneurship</option>
+                                      <option>Finance</option>
+                                      <option>General Management</option>
+                                      <option>Human Resources</option>
+                                      <option>IT Infrastructure</option>
+                                      <option>Innovation</option>
+                                      <option>Investor</option>
+                                      <option>Legal</option>
+                                      <option>Marketing</option>
+                                      <option>Media & Comms</option>
+                                      <option>Merchandising</option>
+                                      <option>Security</option>
+                                      <option>Operations</option>
+                                      <option>Portfolio Operations</option>
+                                      <option>Procurement</option>
+                                      <option>Product Management</option>
+                                      <option>Investor Relations</option>
+                                      <option>Regulatory</option>
+                                      <option>Research</option>
+                                      <option>Risk</option>
+                                      <option>Strategy</option>
+                                      <option>Technology</option>
+                                      <option>Transformation</option>
+                                      <option>Sales & Customer</option>
+                                      <option>Data Science</option>
+                                      <option>Talent Acquisition</option>
+                                      <option>Tax</option>
+                                      <option>Cybersecurity</option>
+                                      <option>Investment Banking</option>
+                                      <option>Supply Chain</option>
+                                    </Select>
+                              </FormControl>
+                              <FormControl p={2} id="company-industry">
+                                <FormLabel>Industry</FormLabel>
+                                <Select required defaultValue={companyInfo.companyIndustry} errorBorderColor='red.300' placeholder="Select industry expertise" name="industryExpertise" onChange={handleChange}>
+                                      <option>Accounting</option>
+                                      <option>Angel Investment</option>
+                                      <option>Asset Management</option>
+                                      <option>Auto Insurance</option>
+                                      <option>Banking</option>
+                                      <option>Bitcoin</option>
+                                      <option>Commercial Insurance</option>
+                                      <option>Commercial Lending</option>
+                                      <option>Credit</option>
+                                      <option>Credit Bureau</option>
+                                      <option>Credit Cards</option>
+                                      <option>Crowdfunding</option>
+                                      <option>Cryptocurrency</option>
+                                      <option>Debit Cards</option>
+                                      <option>Debt Collections</option>
+                                      <option>Finance</option>
+                                      <option>Financial Exchanges</option>
+                                      <option>Financial Services</option>
+                                      <option>FinTech</option>
+                                      <option>Fraud Detection</option>
+                                      <option>Funding Platform</option>
+                                      <option>Gift Card</option>
+                                      <option>Health Insurance</option>
+                                      <option>Hedge Funds</option>
+                                      <option>Impact Investing</option>
+                                      <option>Incubators</option>
+                                      <option>Insurance</option>
+                                      <option>InsurTech</option>
+                                      <option>Leasing</option>
+                                      <option>Lending</option>
+                                      <option>Life Insurance</option>
+                                      <option>Micro Lending</option>
+                                      <option>Mobile Payments</option>
+                                      <option>Payments</option>
+                                      <option>Personal Finance</option>
+                                      <option>Prediction Markets</option>
+                                      <option>Property Insurance</option>
+                                      <option>Real Estate Investment</option>
+                                      <option>Stock Exchanges</option>
+                                      <option>Trading Platform</option>
+                                      <option>Transaction Processing</option>
+                                      <option>Venture Capital</option>
+                                      <option>Virtual Currency</option>
+                                      <option>Wealth Management</option>
+                                    </Select>
+                              </FormControl>
+                        </form>
+              ): null}
             </ModalBody>
             <ModalFooter>
               <Button colorScheme='blue' mr={3} onClick={props.onClose}>

--- a/components/Profile/EditExperienceModal/EditExperienceModal.tsx
+++ b/components/Profile/EditExperienceModal/EditExperienceModal.tsx
@@ -35,7 +35,6 @@ import {
       identity: Identity;
       accType: string;
     }
-  
   }
   
   export interface Identity {
@@ -54,10 +53,26 @@ import {
     currLocation?: string;
     funcExpertise: string;
     industryExpertise: string;
+    companyInfo?: CompanyInfo[];
   }
-
-   export interface BasicProfile {
+  
+  export interface BasicProfile {
     name: string;
+  }
+  export interface Profile {
+      identity: Identity;
+      name: string;
+      accType: string;
+  }
+  
+  export interface CompanyInfo {
+    companyName: string;
+    companyTitle: string;
+    companyImg: any;
+    companyStart: Date;
+    companyEnd: Date;
+    companyFunc: string;
+    companyIndustry: string;
   }
 
 const EditExperienceModal = (props) => {

--- a/components/Profile/EditProfileModal/EditProfileModal.tsx
+++ b/components/Profile/EditProfileModal/EditProfileModal.tsx
@@ -225,13 +225,13 @@ const EditProfileModal = (props) => {
             {/* isInvalid={!!errors.file_} */}
             <FormLabel>{'Update profile picture'}</FormLabel>
 
-                <FileUpload
+                {/* <FileUpload
                 handleFile={handleFile}
                 >
                     <Button>
                     Upload
                     </Button>
-                </FileUpload>
+                </FileUpload> */}
 
                 {/* <FormErrorMessage>
                     {errors.file_ && errors?.file_.message}

--- a/components/Profile/EditProfileModal/EditProfileModal.tsx
+++ b/components/Profile/EditProfileModal/EditProfileModal.tsx
@@ -31,33 +31,48 @@ import { TileDocument } from '@ceramicnetwork/stream-tile';
 const endpoint = "https://ceramic-clay.3boxlabs.com";
 
 export interface ProfileData {
- content: {
-   identity: Identity;
-   accType: string;
- }
-
+  content: {
+    identity: Identity;
+    accType: string;
+  }
 }
 
 export interface Identity {
- firstName: string;
- lastName: string;
- email: string;
- displayName: string;
- bio: string;
- twitterUsrName?: string;
- linkedInUsrName?: string;
- website?: string;
- businessName: string;
- businessType: string;
- businessLocation: string;
- currTitle: string;
- currLocation?: string;
- funcExpertise: string;
- industryExpertise: string;
+  firstName: string;
+  lastName: string;
+  email: string;
+  displayName: string;
+  bio: string;
+  twitterUsrName?: string;
+  linkedInUsrName?: string;
+  website?: string;
+  businessName: string;
+  businessType: string;
+  businessLocation: string;
+  currTitle: string;
+  currLocation?: string;
+  funcExpertise: string;
+  industryExpertise: string;
+  companyInfo?: CompanyInfo[];
 }
 
 export interface BasicProfile {
- name: string;
+  name: string;
+}
+export interface Profile {
+    identity: Identity;
+    name: string;
+    accType: string;
+}
+
+export interface CompanyInfo {
+  companyName: string;
+  companyTitle: string;
+  companyImg: any;
+  companyStart: Date;
+  companyEnd: Date;
+  companyFunc: string;
+  companyIndustry: string;
 }
 
 const EditProfileModal = (props) => {

--- a/components/Profile/Profile.tsx
+++ b/components/Profile/Profile.tsx
@@ -278,7 +278,7 @@ const ProfilePage = () => {
           readProfile();
         }
 
-        function createElements(number){
+        function createWorkElements(number){
           var elements = [];
           let totalLen = profileData.content.identity.companyInfo ? profileData.content.identity.companyInfo.length: 0;
           for(let i = 0; i < number; i++){
@@ -362,7 +362,7 @@ const ProfilePage = () => {
                         <Box alignSelf="flex-start" w="full" overflow='hidden'>
                             <Text pb={8} fontSize='xl'>Work Experience</Text>
                             <HStack spacing={4}>
-                            {createElements(5)}
+                            {createWorkElements(5)}
                             </HStack>
                             <CompanyModal isOpen={isCompanyModalOpen} onClose={onCompanyModalClose} currCompany={currCompany} profileData={profileData} handleUpdatedCompanyInfo={handleUpdatedCompanyInfo}/>
                         </Box>
@@ -407,6 +407,7 @@ const ProfilePage = () => {
     )
 }
 
+// Client-side data fetching for Clearbit's NameToDomain API (on page load)
 const GetCompany = (companyName) => {
   const fetcher = (companyDomain: string,...args: Parameters<typeof fetch>) => fetch(companyDomain).then(response => response.json());
   let paramsObj = {params: companyName.companyName};

--- a/components/Profile/Profile.tsx
+++ b/components/Profile/Profile.tsx
@@ -422,11 +422,11 @@ const GetCompany = (companyName) => {
   return (
     <>
       { data && data.message && data.message.logo ? (
-        <Box w="100px" height="100px" borderRadius='full' backgroundColor='rgb(222, 222, 222)' overflow='hidden' p={4}>
+        <Box w="100px" height="100px" borderRadius='full' backgroundColor='rgb(222, 222, 222)' overflow='hidden' p={4} key={`${data.message.name}--${companyName.currCompany}--box`}>
           <Img
             backgroundColor='rgb(222, 222, 222)'
             style={{ cursor: 'pointer'}}
-            key={data.message.name}
+            key={`${data.message.name}--${companyName.currCompany}`}
             alignSelf="center"
             src={data.message.logo}
             alt='fox stock img'

--- a/components/Profile/Profile.tsx
+++ b/components/Profile/Profile.tsx
@@ -367,7 +367,7 @@ const ProfilePage = () => {
                             <CompanyModal isOpen={isCompanyModalOpen} onClose={onCompanyModalClose} currCompany={currCompany} profileData={profileData} handleUpdatedCompanyInfo={handleUpdatedCompanyInfo}/>
                         </Box>
                         <Box alignSelf="flex-start" w="full" overflow='hidden'>
-                            <Text pt={8} pb={4} fontSize='xl'>Snapshot</Text>
+                            <Text pt={8} pb={4} fontSize='xl'>Web3 Credentials</Text>
                             {snapshotData ? (
                               <>
                             <HStack spacing={4}>
@@ -390,10 +390,10 @@ const ProfilePage = () => {
                           </>
                           ): null}
                         </Box>
-                        <Box alignSelf="flex-start" w="full" overflow='hidden'>
+                        {/* <Box alignSelf="flex-start" w="full" overflow='hidden'>
                             <Text pt={8} pb={4} fontSize='xl'>Book a session with {profileData.content.identity.firstName}</Text>
                             <Button size='md' colorScheme='teal'>Book</Button>
-                        </Box>
+                        </Box> */}
                         </VStack>
                     </Stack>
                 </Box>

--- a/components/Profile/SnapshotModal/SnapshotModal.tsx
+++ b/components/Profile/SnapshotModal/SnapshotModal.tsx
@@ -15,7 +15,6 @@ import {
       identity: Identity;
       accType: string;
     }
-  
   }
   
   export interface Identity {
@@ -34,10 +33,26 @@ import {
     currLocation?: string;
     funcExpertise: string;
     industryExpertise: string;
+    companyInfo?: CompanyInfo[];
   }
-
-   export interface BasicProfile {
+  
+  export interface BasicProfile {
     name: string;
+  }
+  export interface Profile {
+      identity: Identity;
+      name: string;
+      accType: string;
+  }
+  
+  export interface CompanyInfo {
+    companyName: string;
+    companyTitle: string;
+    companyImg: any;
+    companyStart: Date;
+    companyEnd: Date;
+    companyFunc: string;
+    companyIndustry: string;
   }
 
 const SnapshotModal = (props) => {

--- a/components/SignUpSteps/SignUpSteps.tsx
+++ b/components/SignUpSteps/SignUpSteps.tsx
@@ -17,6 +17,51 @@ import { TileDocument } from '@ceramicnetwork/stream-tile';
 // we're using a test network here
 const endpoint = "https://ceramic-clay.3boxlabs.com";
 
+export interface ProfileData {
+  content: {
+    identity: Identity;
+    accType: string;
+  }
+}
+
+export interface Identity {
+  firstName: string;
+  lastName: string;
+  email: string;
+  displayName: string;
+  bio: string;
+  twitterUsrName?: string;
+  linkedInUsrName?: string;
+  website?: string;
+  businessName: string;
+  businessType: string;
+  businessLocation: string;
+  currTitle: string;
+  currLocation?: string;
+  funcExpertise: string;
+  industryExpertise: string;
+  companyInfo?: CompanyInfo[];
+}
+
+export interface BasicProfile {
+  name: string;
+}
+export interface Profile {
+    identity: Identity;
+    name: string;
+    accType: string;
+}
+
+export interface CompanyInfo {
+  companyName: string;
+  companyTitle: string;
+  companyImg: any;
+  companyStart: Date;
+  companyEnd: Date;
+  companyFunc: string;
+  companyIndustry: string;
+}
+
 const userProfileStep = ({ handleChange, values, errors }) => {
   return (<form style={{ alignSelf: "center"}}>
   <Box h="100%" w="xl" borderWidth="1px" borderRadius="lg" overflow="hidden" cursor="pointer">
@@ -267,11 +312,25 @@ const SignUpSteps = () => {
   const [errors, setErrors] = useState({});
   const [accType, setAccType] = useState('');
   const [btnActive, setBtnActive] = useState(0);
-  const [identity, setIdentity] = useState({
-    firstName: "",
-    lastName: "",
-    email: "",
-  })
+
+  const [identity, setIdentity] = useState<Identity>({
+    firstName: '',
+    lastName: '',
+    email: '',
+    displayName: '',
+    bio: '',
+    twitterUsrName: '',
+    linkedInUsrName: '',
+    website: '',
+    businessName: '',
+    businessType: '',
+    businessLocation: '',
+    currTitle: '',
+    currLocation: '',
+    funcExpertise: '',
+    industryExpertise: '',
+    companyInfo: []
+  });
 
   const validate = (values) => {
     let errors: any = {};

--- a/components/SignUpSteps/SignUpSteps.tsx
+++ b/components/SignUpSteps/SignUpSteps.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { Step, Steps, useSteps } from 'chakra-ui-steps';
 import { connect } from '../../utils/walletUtils';
-import { Heading, FormControl, Input, Box, Button, FormLabel, Select, HStack, CircularProgress, Text } from "@chakra-ui/react"
+import { Heading, FormControl, Input, Box, Button, FormLabel, Select, HStack, CircularProgress, Text, FormHelperText } from "@chakra-ui/react"
 import router from 'next/router';
 
 import CeramicClient from '@ceramicnetwork/http-client';
@@ -139,6 +139,7 @@ const merchantProfileStep = ({ handleChange, values, errors }) => {
                         {errors.businessName && (
                           <Text fontSize='xs' fontWeight='400' color='red.500'>{errors.businessName}</Text>
                         )}
+                        <FormHelperText>If you don't have a business name, please use your legal name</FormHelperText>
                       </FormControl>
                       <FormControl p={4} id="business-type" isRequired>
                         <FormLabel>Business type</FormLabel>

--- a/pages/api/cors.tsx
+++ b/pages/api/cors.tsx
@@ -35,6 +35,7 @@ export default async function handler(req, res) {
   }
 }
 
+// Clearbit NameToDomain API request
 const getData = (req, res) => {
   return new Promise((resolve, reject) => {
     var clearbit = require('clearbit')(process.env.CLEARBIT_APIKEY);


### PR DESCRIPTION
Link to shortcut: https://app.shortcut.com/twali/story/90/integrate-logo-api-service

**What this PR includes:**
- hide file upload
- hide booking
- fix for empty company array on page load bug
- Don’t hide company field. Add visible copy that says if you don’t have a business, you can use your Legal name (sole prop)
- Web3 credentials heading is visible for everyone on profile, and let it be blank if they don’t have any
- Disable save btn if the search fails for logo, and provide an error (for now)

**What it looks like:**
<img width="464" alt="Screen Shot 2022-01-28 at 7 54 15 AM" src="https://user-images.githubusercontent.com/16668970/151584215-09bb42aa-902e-4c21-9d39-3280ac9e7bb9.png">
<img width="224" alt="Screen Shot 2022-01-28 at 7 54 25 AM" src="https://user-images.githubusercontent.com/16668970/151584248-7b71fe1f-221e-41bf-a428-6e3d7040c20a.png">
<img width="668" alt="Screen Shot 2022-01-28 at 8 28 16 AM" src="https://user-images.githubusercontent.com/16668970/151584495-c49c802d-213a-4974-babb-3d2a43a67c35.png">

