### PR TITLE
Create a Profile View

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,17 +1,22 @@
 ### What changes were made?
+
 - Eg: The save button colour switches from blue to grey on error
 
 ### Is there any background info about the change?
+
 - Will ensure users can't save incorrect information
 
 ### Are there any state changes? Mention key ones (if any)
+
 - Default: Blue
 - Focus: Grey
 
 ### Screenshots or Gifs✨
+
 <img width="224" alt="Screen Shot 2022-01-28 at 7 54 25 AM" src="https://user-images.githubusercontent.com/16668970/154747093-502817f2-33c8-4197-972d-0d7eb039cfbb.png">
 
 ### Any new dependencies? Why were they added?
+
 - npm package 'we-like-memes'
 - for the memes!
 

--- a/components/Profile/CompanyModal/CompanyModal.tsx
+++ b/components/Profile/CompanyModal/CompanyModal.tsx
@@ -1,6 +1,9 @@
-import { useRef, useState, useEffect } from "react";
+import { useRef, useState } from "react";
 import {
   Box,
+  HStack,
+  VStack,
+  Heading,
   Modal,
   ModalOverlay,
   ModalCloseButton,
@@ -16,6 +19,7 @@ import {
   Input,
   Select,
   Img,
+  Tag,
 } from "@chakra-ui/react";
 import useSWR from "swr";
 import { connect } from "../../../utils/walletUtils";
@@ -27,6 +31,7 @@ import { EthereumAuthProvider, ThreeIdConnect } from "@3id/connect";
 import { DID } from "dids";
 import { IDX } from "@ceramicstudio/idx";
 import { TileDocument } from "@ceramicnetwork/stream-tile";
+import UserPermissionsRestricted from "../../UserPermissionsProvider/UserPermissionsRestricted";
 
 // 3box test nodes with read/write access on ceramic clay testnet
 // network node that we're interacting with, can be local/prod
@@ -132,6 +137,25 @@ const CompanyModal = (props) => {
         ? companyInfo.companyIndustry
         : "",
   });
+
+  const convertDates = (start, end) => {
+    const options: Intl.DateTimeFormatOptions = {
+      year: "numeric",
+      month: "long",
+      day: "numeric",
+    };
+    let newStart = new Date(start).toLocaleDateString(undefined, options);
+    let newEnd = new Date(end).toLocaleDateString(undefined, options);
+    return `${newStart} - ${newEnd}`;
+  };
+
+  let companyDateRange;
+  if (companyInfo && companyInfo.companyStart && companyInfo.companyEnd) {
+    companyDateRange = convertDates(
+      companyInfo.companyStart,
+      companyInfo.companyEnd
+    );
+  }
 
   async function updateCompanyInfo() {
     const address = await connect(); // first address in the array
@@ -283,6 +307,69 @@ const CompanyModal = (props) => {
     setIsDisabled(isDisabled);
   };
 
+  const companyModalView = (
+    <>
+      <ModalContent>
+        <ModalCloseButton />
+        <ModalBody>
+          <VStack spacing={6} padding={10}>
+            {companyInfo ? (
+              <>
+                {companyInfo.companyName ? ( // TODO: We can display a company logo here
+                  <>
+                    {/* <CompanyInfoData
+                companyName={companyInfo.companyName}
+                isDisabled={setDisabled}
+              /> */}
+                    <Heading>{companyInfo.companyName}</Heading>
+                  </>
+                ) : null}
+
+                {companyInfo.companyTitle ? (
+                  <Text fontSize="2xl">{companyInfo.companyTitle}</Text>
+                ) : null}
+
+                {companyInfo.companyStart && companyInfo.companyEnd ? (
+                  <Text fontSize="md" color="gray.500">
+                    {companyDateRange}
+                  </Text>
+                ) : null}
+
+                {companyInfo.companyFunc && companyInfo.companyIndustry ? (
+                  <HStack spacing={4}>
+                    {[companyInfo.companyFunc, companyInfo.companyIndustry].map(
+                      (name) => (
+                        <Tag
+                          size={"md"}
+                          key={`sm--${name}`}
+                          variant="solid"
+                          colorScheme="teal"
+                        >
+                          {name}
+                        </Tag>
+                      )
+                    )}
+                  </HStack>
+                ) : null}
+              </>
+            ) : null}
+          </VStack>
+        </ModalBody>
+        <ModalFooter>
+          <Button
+            colorScheme="blue"
+            mr={3}
+            onClick={() => {
+              props.onClose();
+            }}
+          >
+            Close
+          </Button>
+        </ModalFooter>
+      </ModalContent>
+    </>
+  );
+
   return (
     <>
       <Modal
@@ -293,235 +380,237 @@ const CompanyModal = (props) => {
       >
         <ModalOverlay />
         <ModalContent>
-          <ModalHeader>Update your work experience</ModalHeader>
-          <ModalCloseButton />
-          <ModalBody>
-            {companyInfo ? (
-              <form style={{ alignSelf: "center" }}>
-                <FormControl p={2} id="company-name">
-                  <FormLabel>Company name</FormLabel>
-                  {shouldFetch && (
-                    <CompanyInfoData
-                      companyName={companyName}
-                      isDisabled={setDisabled}
+          <UserPermissionsRestricted to="edit" fallback={companyModalView}>
+            <ModalHeader>Update your work experience</ModalHeader>
+            <ModalCloseButton />
+            <ModalBody>
+              {companyInfo ? (
+                <form style={{ alignSelf: "center" }}>
+                  <FormControl p={2} id="company-name">
+                    <FormLabel>Company name</FormLabel>
+                    {shouldFetch && (
+                      <CompanyInfoData
+                        companyName={companyName}
+                        isDisabled={setDisabled}
+                      />
+                    )}
+                    <Input
+                      required
+                      isInvalid={
+                        errors.companyName &&
+                        (!companyInfo.companyName || !values.companyName)
+                      }
+                      errorBorderColor="red.300"
+                      placeholder="Company name"
+                      name="companyName"
+                      defaultValue={companyInfo.companyName || ""}
+                      onChange={handleChange}
                     />
-                  )}
-                  <Input
-                    required
-                    isInvalid={
-                      errors.companyName &&
-                      (!companyInfo.companyName || !values.companyName)
-                    }
-                    errorBorderColor="red.300"
-                    placeholder="Company name"
-                    name="companyName"
-                    defaultValue={companyInfo.companyName || ""}
-                    onChange={handleChange}
-                  />
-                  {errors.companyName &&
-                    (!companyInfo.companyName || !values.companyName) && (
-                      <Text fontSize="xs" fontWeight="400" color="red.500">
-                        {errors.companyName}
-                      </Text>
-                    )}
-                </FormControl>
-                <FormControl p={2} id="company-title">
-                  <FormLabel>Job title</FormLabel>
-                  <Input
-                    required
-                    isInvalid={
-                      errors.companyTitle &&
-                      (!companyInfo.companyTitle || !values.companyTitle)
-                    }
-                    errorBorderColor="red.300"
-                    placeholder="Job title"
-                    name="companyTitle"
-                    defaultValue={companyInfo.companyTitle || ""}
-                    onChange={handleChange}
-                  />
-                  {errors.companyTitle &&
-                    (!companyInfo.companyTitle || !values.companyTitle) && (
-                      <Text fontSize="xs" fontWeight="400" color="red.500">
-                        {errors.companyTitle}
-                      </Text>
-                    )}
-                </FormControl>
-                <FormControl p={2} id="company-start">
-                  <FormLabel>What was your start date?</FormLabel>
-                  <Input
-                    required
-                    isInvalid={
-                      errors.companyStart &&
-                      (!companyInfo.companyStart || !values.companyStart)
-                    }
-                    errorBorderColor="red.300"
-                    name="companyStart"
-                    defaultValue={companyInfo.companyStart || ""}
-                    onChange={handleChange}
-                  />
-                  {errors.companyStart &&
-                    (!companyInfo.companyStart || !values.companyStart) && (
-                      <Text fontSize="xs" fontWeight="400" color="red.500">
-                        {errors.companyStart}
-                      </Text>
-                    )}
-                </FormControl>
-                <FormControl p={2} id="company-end">
-                  <FormLabel>What was your end date?</FormLabel>
-                  <Input
-                    required
-                    isInvalid={
-                      errors.companyEnd &&
-                      (!companyInfo.companyEnd || !values.companyEnd)
-                    }
-                    errorBorderColor="red.300"
-                    name="companyEnd"
-                    defaultValue={companyInfo.companyEnd || ""}
-                    onChange={handleChange}
-                  />
-                  {errors.companyEnd &&
-                    (!companyInfo.companyEnd || !values.companyEnd) && (
-                      <Text fontSize="xs" fontWeight="400" color="red.500">
-                        {errors.companyEnd}
-                      </Text>
-                    )}
-                </FormControl>
-                <FormControl p={2} id="company-func">
-                  <FormLabel>Functional expertise</FormLabel>
-                  <Select
-                    required
-                    defaultValue={companyInfo.companyFunc}
-                    errorBorderColor="red.300"
-                    placeholder="Select functional expertise"
-                    name="funcExpertise"
-                    onChange={handleChange}
-                  >
-                    <option>Accounting</option>
-                    <option>Creative</option>
-                    <option>Audit</option>
-                    <option>Board & Advisory</option>
-                    <option>Corporate Development</option>
-                    <option>Comp & Benefits</option>
-                    <option>Compliance</option>
-                    <option>Management Consulting</option>
-                    <option>Data & Analytics</option>
-                    <option>Product Design</option>
-                    <option>Digital</option>
-                    <option>Engineering</option>
-                    <option>Entrepreneurship</option>
-                    <option>Finance</option>
-                    <option>General Management</option>
-                    <option>Human Resources</option>
-                    <option>IT Infrastructure</option>
-                    <option>Innovation</option>
-                    <option>Investor</option>
-                    <option>Legal</option>
-                    <option>Marketing</option>
-                    <option>Media & Comms</option>
-                    <option>Merchandising</option>
-                    <option>Security</option>
-                    <option>Operations</option>
-                    <option>Portfolio Operations</option>
-                    <option>Procurement</option>
-                    <option>Product Management</option>
-                    <option>Investor Relations</option>
-                    <option>Regulatory</option>
-                    <option>Research</option>
-                    <option>Risk</option>
-                    <option>Strategy</option>
-                    <option>Technology</option>
-                    <option>Transformation</option>
-                    <option>Sales & Customer</option>
-                    <option>Data Science</option>
-                    <option>Talent Acquisition</option>
-                    <option>Tax</option>
-                    <option>Cybersecurity</option>
-                    <option>Investment Banking</option>
-                    <option>Supply Chain</option>
-                  </Select>
-                </FormControl>
-                <FormControl p={2} id="company-industry">
-                  <FormLabel>Industry</FormLabel>
-                  <Select
-                    required
-                    defaultValue={companyInfo.companyIndustry}
-                    errorBorderColor="red.300"
-                    placeholder="Select industry expertise"
-                    name="industryExpertise"
-                    onChange={handleChange}
-                  >
-                    <option>Accounting</option>
-                    <option>Angel Investment</option>
-                    <option>Asset Management</option>
-                    <option>Auto Insurance</option>
-                    <option>Banking</option>
-                    <option>Bitcoin</option>
-                    <option>Commercial Insurance</option>
-                    <option>Commercial Lending</option>
-                    <option>Credit</option>
-                    <option>Credit Bureau</option>
-                    <option>Credit Cards</option>
-                    <option>Crowdfunding</option>
-                    <option>Cryptocurrency</option>
-                    <option>Debit Cards</option>
-                    <option>Debt Collections</option>
-                    <option>Finance</option>
-                    <option>Financial Exchanges</option>
-                    <option>Financial Services</option>
-                    <option>FinTech</option>
-                    <option>Fraud Detection</option>
-                    <option>Funding Platform</option>
-                    <option>Gift Card</option>
-                    <option>Health Insurance</option>
-                    <option>Hedge Funds</option>
-                    <option>Impact Investing</option>
-                    <option>Incubators</option>
-                    <option>Insurance</option>
-                    <option>InsurTech</option>
-                    <option>Leasing</option>
-                    <option>Lending</option>
-                    <option>Life Insurance</option>
-                    <option>Micro Lending</option>
-                    <option>Mobile Payments</option>
-                    <option>Payments</option>
-                    <option>Personal Finance</option>
-                    <option>Prediction Markets</option>
-                    <option>Property Insurance</option>
-                    <option>Real Estate Investment</option>
-                    <option>Stock Exchanges</option>
-                    <option>Trading Platform</option>
-                    <option>Transaction Processing</option>
-                    <option>Venture Capital</option>
-                    <option>Virtual Currency</option>
-                    <option>Wealth Management</option>
-                  </Select>
-                </FormControl>
-              </form>
-            ) : null}
-          </ModalBody>
-          <ModalFooter>
-            <Button colorScheme="blue" mr={3} onClick={props.onClose}>
-              Close
-            </Button>
-            <Button
-              isDisabled={isDisabled}
-              onClick={() => {
-                setShouldFetch(false);
-                updateCompanyInfo();
-              }}
-              variant="ghost"
-            >
-              Save{" "}
-              {isSubmitted ? (
-                <CircularProgress
-                  size="22px"
-                  thickness="4px"
-                  isIndeterminate
-                  color="#3C2E26"
-                />
+                    {errors.companyName &&
+                      (!companyInfo.companyName || !values.companyName) && (
+                        <Text fontSize="xs" fontWeight="400" color="red.500">
+                          {errors.companyName}
+                        </Text>
+                      )}
+                  </FormControl>
+                  <FormControl p={2} id="company-title">
+                    <FormLabel>Job title</FormLabel>
+                    <Input
+                      required
+                      isInvalid={
+                        errors.companyTitle &&
+                        (!companyInfo.companyTitle || !values.companyTitle)
+                      }
+                      errorBorderColor="red.300"
+                      placeholder="Job title"
+                      name="companyTitle"
+                      defaultValue={companyInfo.companyTitle || ""}
+                      onChange={handleChange}
+                    />
+                    {errors.companyTitle &&
+                      (!companyInfo.companyTitle || !values.companyTitle) && (
+                        <Text fontSize="xs" fontWeight="400" color="red.500">
+                          {errors.companyTitle}
+                        </Text>
+                      )}
+                  </FormControl>
+                  <FormControl p={2} id="company-start">
+                    <FormLabel>What was your start date?</FormLabel>
+                    <Input
+                      required
+                      isInvalid={
+                        errors.companyStart &&
+                        (!companyInfo.companyStart || !values.companyStart)
+                      }
+                      errorBorderColor="red.300"
+                      name="companyStart"
+                      defaultValue={companyInfo.companyStart || ""}
+                      onChange={handleChange}
+                    />
+                    {errors.companyStart &&
+                      (!companyInfo.companyStart || !values.companyStart) && (
+                        <Text fontSize="xs" fontWeight="400" color="red.500">
+                          {errors.companyStart}
+                        </Text>
+                      )}
+                  </FormControl>
+                  <FormControl p={2} id="company-end">
+                    <FormLabel>What was your end date?</FormLabel>
+                    <Input
+                      required
+                      isInvalid={
+                        errors.companyEnd &&
+                        (!companyInfo.companyEnd || !values.companyEnd)
+                      }
+                      errorBorderColor="red.300"
+                      name="companyEnd"
+                      defaultValue={companyInfo.companyEnd || ""}
+                      onChange={handleChange}
+                    />
+                    {errors.companyEnd &&
+                      (!companyInfo.companyEnd || !values.companyEnd) && (
+                        <Text fontSize="xs" fontWeight="400" color="red.500">
+                          {errors.companyEnd}
+                        </Text>
+                      )}
+                  </FormControl>
+                  <FormControl p={2} id="company-func">
+                    <FormLabel>Functional expertise</FormLabel>
+                    <Select
+                      required
+                      defaultValue={companyInfo.companyFunc}
+                      errorBorderColor="red.300"
+                      placeholder="Select functional expertise"
+                      name="funcExpertise"
+                      onChange={handleChange}
+                    >
+                      <option>Accounting</option>
+                      <option>Creative</option>
+                      <option>Audit</option>
+                      <option>Board & Advisory</option>
+                      <option>Corporate Development</option>
+                      <option>Comp & Benefits</option>
+                      <option>Compliance</option>
+                      <option>Management Consulting</option>
+                      <option>Data & Analytics</option>
+                      <option>Product Design</option>
+                      <option>Digital</option>
+                      <option>Engineering</option>
+                      <option>Entrepreneurship</option>
+                      <option>Finance</option>
+                      <option>General Management</option>
+                      <option>Human Resources</option>
+                      <option>IT Infrastructure</option>
+                      <option>Innovation</option>
+                      <option>Investor</option>
+                      <option>Legal</option>
+                      <option>Marketing</option>
+                      <option>Media & Comms</option>
+                      <option>Merchandising</option>
+                      <option>Security</option>
+                      <option>Operations</option>
+                      <option>Portfolio Operations</option>
+                      <option>Procurement</option>
+                      <option>Product Management</option>
+                      <option>Investor Relations</option>
+                      <option>Regulatory</option>
+                      <option>Research</option>
+                      <option>Risk</option>
+                      <option>Strategy</option>
+                      <option>Technology</option>
+                      <option>Transformation</option>
+                      <option>Sales & Customer</option>
+                      <option>Data Science</option>
+                      <option>Talent Acquisition</option>
+                      <option>Tax</option>
+                      <option>Cybersecurity</option>
+                      <option>Investment Banking</option>
+                      <option>Supply Chain</option>
+                    </Select>
+                  </FormControl>
+                  <FormControl p={2} id="company-industry">
+                    <FormLabel>Industry</FormLabel>
+                    <Select
+                      required
+                      defaultValue={companyInfo.companyIndustry}
+                      errorBorderColor="red.300"
+                      placeholder="Select industry expertise"
+                      name="industryExpertise"
+                      onChange={handleChange}
+                    >
+                      <option>Accounting</option>
+                      <option>Angel Investment</option>
+                      <option>Asset Management</option>
+                      <option>Auto Insurance</option>
+                      <option>Banking</option>
+                      <option>Bitcoin</option>
+                      <option>Commercial Insurance</option>
+                      <option>Commercial Lending</option>
+                      <option>Credit</option>
+                      <option>Credit Bureau</option>
+                      <option>Credit Cards</option>
+                      <option>Crowdfunding</option>
+                      <option>Cryptocurrency</option>
+                      <option>Debit Cards</option>
+                      <option>Debt Collections</option>
+                      <option>Finance</option>
+                      <option>Financial Exchanges</option>
+                      <option>Financial Services</option>
+                      <option>FinTech</option>
+                      <option>Fraud Detection</option>
+                      <option>Funding Platform</option>
+                      <option>Gift Card</option>
+                      <option>Health Insurance</option>
+                      <option>Hedge Funds</option>
+                      <option>Impact Investing</option>
+                      <option>Incubators</option>
+                      <option>Insurance</option>
+                      <option>InsurTech</option>
+                      <option>Leasing</option>
+                      <option>Lending</option>
+                      <option>Life Insurance</option>
+                      <option>Micro Lending</option>
+                      <option>Mobile Payments</option>
+                      <option>Payments</option>
+                      <option>Personal Finance</option>
+                      <option>Prediction Markets</option>
+                      <option>Property Insurance</option>
+                      <option>Real Estate Investment</option>
+                      <option>Stock Exchanges</option>
+                      <option>Trading Platform</option>
+                      <option>Transaction Processing</option>
+                      <option>Venture Capital</option>
+                      <option>Virtual Currency</option>
+                      <option>Wealth Management</option>
+                    </Select>
+                  </FormControl>
+                </form>
               ) : null}
-            </Button>
-          </ModalFooter>
+            </ModalBody>
+            <ModalFooter>
+              <Button colorScheme="blue" mr={3} onClick={props.onClose}>
+                Close
+              </Button>
+              <Button
+                isDisabled={isDisabled}
+                onClick={() => {
+                  setShouldFetch(false);
+                  updateCompanyInfo();
+                }}
+                variant="ghost"
+              >
+                Save{" "}
+                {isSubmitted ? (
+                  <CircularProgress
+                    size="22px"
+                    thickness="4px"
+                    isIndeterminate
+                    color="#3C2E26"
+                  />
+                ) : null}
+              </Button>
+            </ModalFooter>
+          </UserPermissionsRestricted>
         </ModalContent>
       </Modal>
     </>

--- a/components/Profile/Profile.tsx
+++ b/components/Profile/Profile.tsx
@@ -1,6 +1,5 @@
 import {
   Box,
-  Button,
   Img,
   VStack,
   HStack,
@@ -28,6 +27,9 @@ import { request, gql } from "graphql-request";
 import SnapshotModal from "./SnapshotModal/SnapshotModal";
 import CompanyModal from "./CompanyModal/CompanyModal";
 import useSWR from "swr";
+import UserPermissionsProvider from "../UserPermissionsProvider/UserPermissionsProvider";
+import UserPermissionsRestricted from "../UserPermissionsProvider/UserPermissionsRestricted";
+import { fetchPermission } from "../../utils/profileUtils";
 
 // network node that we're interacting with, can be local/prod
 // we're using a test network here
@@ -324,24 +326,37 @@ const ProfilePage = () => {
         );
       } else {
         elements.push(
-          <Img
-            key={`${i}--empty-company-exp`}
-            borderRadius="full"
-            style={{ cursor: "pointer" }}
-            backgroundColor="lightgray"
-            width="100px"
-            src="add.svg"
-            alt="add img"
-            onClick={() => {
-              setCurrCompany(i);
-              onCompanyModalOpen();
-            }}
-          />
+          <UserPermissionsRestricted to="edit">
+            <Img
+              key={`${i}--empty-company-exp`}
+              borderRadius="full"
+              style={{ cursor: "pointer" }}
+              backgroundColor="lightgray"
+              width="100px"
+              src="add.svg"
+              alt="add img"
+              onClick={() => {
+                setCurrCompany(i);
+                onCompanyModalOpen();
+              }}
+            />
+          </UserPermissionsRestricted>
         );
       }
     }
     return elements;
   }
+
+  const viewCompany = (
+    <CompanyModal
+      isOpen={isCompanyModalOpen}
+      onClose={onCompanyModalClose}
+      currCompany={currCompany}
+      profileData={profileData}
+      userPermission="view"
+      handleUpdatedCompanyInfo={handleUpdatedCompanyInfo}
+    />
+  );
 
   return (
     <>
@@ -362,189 +377,213 @@ const ProfilePage = () => {
         profileData.content.accType &&
         profileData.content.identity && (
           <>
-            <Box w="full" borderWidth="1px" borderRadius="lg" overflow="hidden">
-              <Img
-                objectFit="cover"
-                width="100%"
-                height="200px"
-                overflow="hidden"
-                src="https://i.pinimg.com/originals/92/4e/c3/924ec3d75761aa0e5b84e4031f718de6.jpg"
-                alt="aesthetic brown"
-              />
-            </Box>
-            <HStack w="full" spacing={24}>
-              <VStack
-                marginTop={0}
-                paddingTop={0}
-                align="flex-start"
-                spacing={6}
-              >
-                <Box alignSelf="flex-start" overflow="hidden">
-                  <Img
-                    borderRadius="full"
-                    width="500px"
-                    src="fox-pfp.png"
-                    alt="fox stock img"
-                  />
-                </Box>
-                <IconButton
-                  onClick={onExpModalOpen}
-                  alignSelf="flex-end"
-                  variant="ghost"
-                  aria-label="Update experience"
-                  icon={<FontAwesomeIcon size="sm" icon={["fas", "edit"]} />}
-                />
-                <EditExperienceModal
-                  isOpen={isExpModalOpen}
-                  onClose={onExpModalClose}
-                  profileData={profileData}
-                  handleUpdatedExperiences={handleUpdatedProfile}
-                />
-                {profileData.content.identity.displayName && (
-                  <Text fontSize="xl">
-                    @{profileData.content.identity.displayName}
-                  </Text>
-                )}
-                {profileData.content.identity.email && (
-                  <Text fontSize="md">
-                    {profileData.content.identity.email}
-                  </Text>
-                )}
-                <Box
-                  p={4}
-                  ml={8}
-                  borderWidth="1px"
-                  color="rgb(0, 0, 0)"
-                  borderRadius="lg"
-                  overflow="hidden"
-                  backgroundColor="rgb(222, 222, 222)"
-                >
-                  {profileData &&
-                    profileData.content.identity &&
-                    profileData.content.identity.funcExpertise && (
-                      <Text fontSize="md">
-                        {profileData.content.identity.funcExpertise}
-                      </Text>
-                    )}
-                </Box>
-                <Box
-                  p={4}
-                  ml={8}
-                  borderWidth="1px"
-                  borderRadius="lg"
-                  overflow="hidden"
-                  color="rgb(0, 0, 0)"
-                  backgroundColor="rgb(222, 222, 222)"
-                >
-                  {profileData &&
-                    profileData.content.identity &&
-                    profileData.content.identity.industryExpertise && (
-                      <Text fontSize="md">
-                        {profileData.content.identity.industryExpertise}
-                      </Text>
-                    )}
-                </Box>
-              </VStack>
+            <UserPermissionsProvider
+              fetchPermission={fetchPermission(
+                profileData.content.identity.displayName
+              )}
+            >
               <Box
-                alignSelf="flex-start"
                 w="full"
-                pt={16}
-                pl={4}
+                borderWidth="1px"
+                borderRadius="lg"
                 overflow="hidden"
               >
-                <Stack spacing={6}>
-                  <HStack>
+                <Img
+                  objectFit="cover"
+                  width="100%"
+                  height="200px"
+                  overflow="hidden"
+                  src="https://i.pinimg.com/originals/92/4e/c3/924ec3d75761aa0e5b84e4031f718de6.jpg"
+                  alt="aesthetic brown"
+                />
+              </Box>
+              <HStack w="full" spacing={24}>
+                <VStack
+                  marginTop={0}
+                  paddingTop={0}
+                  align="flex-start"
+                  spacing={6}
+                >
+                  <Box alignSelf="flex-start" overflow="hidden">
+                    <Img
+                      borderRadius="full"
+                      width="500px"
+                      src="fox-pfp.png"
+                      alt="fox stock img"
+                    />
+                  </Box>
+                  <UserPermissionsRestricted to="edit">
+                    <IconButton
+                      onClick={onExpModalOpen}
+                      alignSelf="flex-end"
+                      variant="ghost"
+                      aria-label="Update experience"
+                      icon={
+                        <FontAwesomeIcon size="sm" icon={["fas", "edit"]} />
+                      }
+                    />
+                    <EditExperienceModal
+                      isOpen={isExpModalOpen}
+                      onClose={onExpModalClose}
+                      profileData={profileData}
+                      handleUpdatedExperiences={handleUpdatedProfile}
+                    />
+                  </UserPermissionsRestricted>
+                  {profileData.content.identity.displayName && (
                     <Text fontSize="xl">
-                      {name + ", " + profileData.content.accType}
-                    </Text>
-                    <FontAwesomeIcon size="lg" icon={["fas", "map-pin"]} />
-                    {profileData.content.identity.businessLocation && (
-                      <Text fontSize="md">
-                        {profileData.content.identity.businessLocation}
-                      </Text>
-                    )}
-                  </HStack>
-                  <Text fontSize="md">
-                    {profileData.content.identity.currTitle}
-                  </Text>
-                  {profileData.content.identity.bio && (
-                    <Text fontSize="md">
-                      {profileData.content.identity.bio}
+                      @{profileData.content.identity.displayName}
                     </Text>
                   )}
-                  )
-                  <VStack>
-                    <Box alignSelf="flex-start" w="full" overflow="hidden">
-                      <Text pb={8} fontSize="xl">
-                        Work Experience
+                  {profileData.content.identity.email && (
+                    <Text fontSize="md">
+                      {profileData.content.identity.email}
+                    </Text>
+                  )}
+                  <Box
+                    p={4}
+                    ml={8}
+                    borderWidth="1px"
+                    color="rgb(0, 0, 0)"
+                    borderRadius="lg"
+                    overflow="hidden"
+                    backgroundColor="rgb(222, 222, 222)"
+                  >
+                    {profileData &&
+                      profileData.content.identity &&
+                      profileData.content.identity.funcExpertise && (
+                        <Text fontSize="md">
+                          {profileData.content.identity.funcExpertise}
+                        </Text>
+                      )}
+                  </Box>
+                  <Box
+                    p={4}
+                    ml={8}
+                    borderWidth="1px"
+                    borderRadius="lg"
+                    overflow="hidden"
+                    color="rgb(0, 0, 0)"
+                    backgroundColor="rgb(222, 222, 222)"
+                  >
+                    {profileData &&
+                      profileData.content.identity &&
+                      profileData.content.identity.industryExpertise && (
+                        <Text fontSize="md">
+                          {profileData.content.identity.industryExpertise}
+                        </Text>
+                      )}
+                  </Box>
+                </VStack>
+                <Box
+                  alignSelf="flex-start"
+                  w="full"
+                  pt={16}
+                  pl={4}
+                  overflow="hidden"
+                >
+                  <Stack spacing={6}>
+                    <HStack>
+                      <Text fontSize="xl">
+                        {name + ", " + profileData.content.accType}
                       </Text>
-                      <HStack spacing={4}>{createWorkElements(5)}</HStack>
-                      <CompanyModal
-                        isOpen={isCompanyModalOpen}
-                        onClose={onCompanyModalClose}
-                        currCompany={currCompany}
-                        profileData={profileData}
-                        handleUpdatedCompanyInfo={handleUpdatedCompanyInfo}
-                      />
-                    </Box>
-                    <Box alignSelf="flex-start" w="full" overflow="hidden">
-                      <Text pt={8} pb={4} fontSize="xl">
-                        Web3 Credentials
+                      <FontAwesomeIcon size="lg" icon={["fas", "map-pin"]} />
+                      {profileData.content.identity.businessLocation && (
+                        <Text fontSize="md">
+                          {profileData.content.identity.businessLocation}
+                        </Text>
+                      )}
+                    </HStack>
+                    <Text fontSize="md">
+                      {profileData.content.identity.currTitle}
+                    </Text>
+                    {profileData.content.identity.bio && (
+                      <Text fontSize="md">
+                        {profileData.content.identity.bio}
                       </Text>
-                      {snapshotData ? (
-                        <>
-                          <HStack spacing={4}>
-                            {snapshotData.map((vote) => (
-                              <Img
-                                style={{ cursor: "pointer" }}
-                                key={vote.spaceID}
-                                borderRadius="full"
-                                width="100px"
-                                src={vote.avatar}
-                                alt="fox stock img"
-                                onClick={() => {
-                                  setCurrentSnapshot(vote);
-                                  onSnapshotModalOpen();
-                                }}
-                              />
-                            ))}
-                          </HStack>
-                          <SnapshotModal
-                            isOpen={isSnapshotModalOpen}
-                            onClose={onSnapshotModalClose}
-                            snapshotData={currentSnapshot}
+                    )}
+                    )
+                    <VStack>
+                      <Box alignSelf="flex-start" w="full" overflow="hidden">
+                        <Text pb={8} fontSize="xl">
+                          Work Experience
+                        </Text>
+                        <HStack spacing={4}>{createWorkElements(5)}</HStack>
+                        <UserPermissionsRestricted
+                          to="edit"
+                          fallback={viewCompany}
+                        >
+                          <CompanyModal
+                            isOpen={isCompanyModalOpen}
+                            onClose={onCompanyModalClose}
+                            currCompany={currCompany}
+                            profileData={profileData}
+                            handleUpdatedCompanyInfo={handleUpdatedCompanyInfo}
                           />
-                        </>
-                      ) : null}
-                    </Box>
-                    {/* <Box alignSelf="flex-start" w="full" overflow='hidden'>
+                        </UserPermissionsRestricted>
+                      </Box>
+                      <Box alignSelf="flex-start" w="full" overflow="hidden">
+                        <Text pt={8} pb={4} fontSize="xl">
+                          Web3 Credentials
+                        </Text>
+                        {snapshotData ? (
+                          <>
+                            <HStack spacing={4}>
+                              {snapshotData.map((vote) => (
+                                <Img
+                                  style={{ cursor: "pointer" }}
+                                  key={vote.spaceID}
+                                  borderRadius="full"
+                                  width="100px"
+                                  src={vote.avatar}
+                                  alt="fox stock img"
+                                  onClick={() => {
+                                    setCurrentSnapshot(vote);
+                                    onSnapshotModalOpen();
+                                  }}
+                                />
+                              ))}
+                            </HStack>
+                            <SnapshotModal
+                              isOpen={isSnapshotModalOpen}
+                              onClose={onSnapshotModalClose}
+                              snapshotData={currentSnapshot}
+                            />
+                          </>
+                        ) : null}
+                      </Box>
+                      {/* <Box alignSelf="flex-start" w="full" overflow='hidden'>
                             <Text pt={8} pb={4} fontSize='xl'>Book a session with {profileData.content.identity.firstName}</Text>
                             <Button size='md' colorScheme='teal'>Book</Button>
                         </Box> */}
-                  </VStack>
-                </Stack>
-              </Box>
-              <Box
-                marginTop={8}
-                w="150px"
-                alignSelf="flex-start"
-                overflow="hidden"
-              >
-                <IconButton
-                  onClick={onProfileModalOpen}
-                  alignSelf="flex-end"
-                  variant="ghost"
-                  aria-label="Update experience"
-                  icon={<FontAwesomeIcon size="sm" icon={["fas", "edit"]} />}
-                />
-                <EditProfileModal
-                  isOpen={isProfileModalOpen}
-                  onClose={onProfileModalClose}
-                  profileData={profileData}
-                  handleUpdatedProfile={handleUpdatedProfile}
-                />
-              </Box>
-            </HStack>
+                    </VStack>
+                  </Stack>
+                </Box>
+                <Box
+                  marginTop={8}
+                  w="150px"
+                  alignSelf="flex-start"
+                  overflow="hidden"
+                >
+                  <UserPermissionsRestricted to="edit">
+                    <IconButton
+                      onClick={onProfileModalOpen}
+                      alignSelf="flex-end"
+                      variant="ghost"
+                      aria-label="Update experience"
+                      icon={
+                        <FontAwesomeIcon size="sm" icon={["fas", "edit"]} />
+                      }
+                    />
+                    <EditProfileModal
+                      isOpen={isProfileModalOpen}
+                      onClose={onProfileModalClose}
+                      profileData={profileData}
+                      handleUpdatedProfile={handleUpdatedProfile}
+                    />
+                  </UserPermissionsRestricted>
+                </Box>
+              </HStack>
+            </UserPermissionsProvider>
           </>
         )
       )}
@@ -578,20 +617,36 @@ const GetCompany = (companyName) => {
           p={4}
           key={`${data.message.name}--${companyName.currCompany}--box`}
         >
-          <Img
-            backgroundColor="rgb(222, 222, 222)"
-            style={{ cursor: "pointer" }}
-            key={`${data.message.name}--${companyName.currCompany}`}
-            alignSelf="center"
-            src={data.message.logo}
-            alt="fox stock img"
-            onMouseEnter={(e) => (e.currentTarget.src = "edit.svg")}
-            onMouseLeave={(e) => (e.currentTarget.src = data.message.logo)}
-            onClick={() => {
-              companyName.setCurrCompany(companyName.currCompany);
-              companyName.onCompanyModalOpen();
-            }}
-          />
+          <UserPermissionsRestricted to="view">
+            <Img
+              backgroundColor="rgb(222, 222, 222)"
+              style={{ cursor: "pointer" }}
+              key={`${data.message.name}--${companyName.currCompany}`}
+              alignSelf="center"
+              src={data.message.logo}
+              alt="fox stock img"
+              onClick={() => {
+                companyName.setCurrCompany(companyName.currCompany);
+                companyName.onCompanyModalOpen();
+              }}
+            />
+          </UserPermissionsRestricted>
+          <UserPermissionsRestricted to="edit">
+            <Img
+              backgroundColor="rgb(222, 222, 222)"
+              style={{ cursor: "pointer" }}
+              key={`${data.message.name}--${companyName.currCompany}`}
+              alignSelf="center"
+              src={data.message.logo}
+              alt="fox stock img"
+              onMouseEnter={(e) => (e.currentTarget.src = "edit.svg")}
+              onMouseLeave={(e) => (e.currentTarget.src = data.message.logo)}
+              onClick={() => {
+                companyName.setCurrCompany(companyName.currCompany);
+                companyName.onCompanyModalOpen();
+              }}
+            />
+          </UserPermissionsRestricted>
         </Box>
       ) : (
         <Img

--- a/components/UserPermissionsProvider/UserPermissionsContext.ts
+++ b/components/UserPermissionsProvider/UserPermissionsContext.ts
@@ -1,0 +1,19 @@
+import React from "react";
+import { Permission } from "../../utils/PermissionTypes";
+
+type UserPermissionsContextType = {
+  isAllowedTo: (permission: Permission) => Promise<boolean>;
+};
+
+// Default behaviour for the Permission Provider Context
+// i.e. if for whatever reason the consumer is used outside of a provider
+// The permission will not be granted if no provider says otherwise
+const defaultBehaviour: UserPermissionsContextType = {
+  isAllowedTo: () => Promise.resolve(false),
+};
+
+// Create the context
+const UserPermissionsContext =
+  React.createContext<UserPermissionsContextType>(defaultBehaviour);
+
+export default UserPermissionsContext;

--- a/components/UserPermissionsProvider/UserPermissionsProvider.tsx
+++ b/components/UserPermissionsProvider/UserPermissionsProvider.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { Permission } from "../../utils/PermissionTypes";
+import UserPermissionsContext from "./UserPermissionsContext";
+
+type Props = {
+  fetchPermission: (p: Permission) => Promise<boolean>;
+};
+
+type UserPermissionCache = {
+  [key: string]: boolean;
+};
+
+// This provider is intended to be surrounding the whole application.
+// It should receive the users permissions as parameter
+const UserPermissionProvider: React.FunctionComponent<Props> = ({
+  fetchPermission,
+  children,
+}) => {
+  const cache: UserPermissionCache = {};
+
+  // Creates a method that returns whether the requested permission is available in the list of permissions
+  // passed as parameter
+  const isAllowedTo = async (permission: Permission): Promise<boolean> => {
+    if (Object.keys(cache).includes(permission)) {
+      return cache[permission];
+    }
+    const isAllowed = await fetchPermission(permission);
+    cache[permission] = isAllowed;
+    return isAllowed;
+  };
+
+  // This component will render its children wrapped around a PermissionContext's provider whose
+  // value is set to the method defined above
+  return (
+    <UserPermissionsContext.Provider value={{ isAllowedTo }}>
+      {children}
+    </UserPermissionsContext.Provider>
+  );
+};
+
+export default UserPermissionProvider;

--- a/components/UserPermissionsProvider/UserPermissionsRestricted.tsx
+++ b/components/UserPermissionsProvider/UserPermissionsRestricted.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import { Permission } from "../../utils/PermissionTypes";
+import enablePermission from "./enablePermission";
+
+type Props = {
+  to: Permission;
+  fallback?: JSX.Element | string;
+  loadingComponent?: JSX.Element | string;
+};
+
+// This component is meant to be used everywhere a restriction based on user permission is needed
+const UserPermissionsRestricted: React.FunctionComponent<Props> = ({
+  to,
+  fallback,
+  loadingComponent,
+  children,
+}) => {
+  // We "connect" to the provider thanks to the PermissionContext
+  const [loading, allowed] = enablePermission(to);
+
+  if (loading) {
+    return <>{loadingComponent}</>;
+  }
+
+  // If the user has that permission, render the children
+  if (allowed) {
+    return <>{children}</>;
+  }
+
+  // Otherwise, render the fallback
+  return <>{fallback}</>;
+};
+
+export default UserPermissionsRestricted;

--- a/components/UserPermissionsProvider/enablePermission.ts
+++ b/components/UserPermissionsProvider/enablePermission.ts
@@ -1,0 +1,18 @@
+import { useContext, useState } from "react";
+import PermissionContext from "./UserPermissionsContext";
+import { Permission } from "../../utils/PermissionTypes";
+
+const enablePermission = (permission: Permission) => {
+  const [loading, setLoading] = useState(true);
+  const [allowed, setAllowed] = useState<boolean>();
+
+  const { isAllowedTo } = useContext(PermissionContext);
+
+  isAllowedTo(permission).then((allowed) => {
+    setLoading(false);
+    setAllowed(allowed);
+  });
+  return [loading, allowed];
+};
+
+export default enablePermission;

--- a/utils/PermissionTypes.ts
+++ b/utils/PermissionTypes.ts
@@ -1,0 +1,6 @@
+export type Permission = string;
+
+export type User = {
+  userName: string;
+  permissions: Permission[];
+};

--- a/utils/profileUtils.tsx
+++ b/utils/profileUtils.tsx
@@ -1,0 +1,17 @@
+import { Permission } from "./PermissionTypes";
+
+// Function that simulates fetching a permission from remote server
+export const fetchPermission =
+  (displayName) =>
+  async (permission: Permission): Promise<boolean> => {
+    console.log(displayName);
+
+    let user = {
+      userName: "nagmak",
+      permissions: ["edit"],
+    };
+    // permissions: ["view"] for restricted
+    // Simulate a delay from a request
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+    return user.permissions.includes(permission);
+  };


### PR DESCRIPTION
### What changes were made?
- Added user permissions component scaffolding
- Hiding any edit buttons
- Created a simple company modal view that users with 'view' only permission can see
- Hiding any empty company spots from 'view' only users
- A profileUtils.tsx file to clean up the main file a bit
- Some prettier changes to the PR template

### Is there any background info about the change?
- We need two main permissions for users: edit and view
- When the currently logged in user enters their profile, they should be able to edit it and view it
- When a link to a profile is shared with someone else (that isn't the profile user), then they should only be able to view it
- The full functionality isn't fleshed out yet but this is scaffolding to get there

### Are there any state changes? Mention key ones (if any)
- companyDateRange
- this is updated when the company modal opens to display a human readable date range
- this only happens for a user with 'view' only permission

### Screenshots or Gifs✨

<img width="1422" alt="Screen Shot 2022-02-22 at 4 31 42 PM" src="https://user-images.githubusercontent.com/16668970/155224945-7fa09d21-ab27-4585-8cb7-0a82ee293b4f.png">

<img width="545" alt="Screen Shot 2022-02-22 at 4 31 52 PM" src="https://user-images.githubusercontent.com/16668970/155224888-0d3ebd70-32ed-4db2-841a-5d276d1924cf.png">

### Any new dependencies? Why were they added?
None

### Shortcut Link

https://app.shortcut.com/twali/story/272/create-a-profile-view
