### PR TITLE
Fix default values

### DIFF
--- a/components/Landing/LottieAnimation.tsx
+++ b/components/Landing/LottieAnimation.tsx
@@ -1,14 +1,14 @@
 import Lottie from "lottie-web";
 import { Box } from "@chakra-ui/react";
 import React, { createRef, useEffect } from "react";
-
-export default function LottieAnimation({ animation, ...props }) {
+// find available options @ https://airbnb.io/lottie/#/web
+export default function LottieAnimation({ options, ...props }) {
   let lottieAnimation = createRef<HTMLDivElement>();
 
   useEffect(() => {
-    const animate = Lottie.loadAnimation({
+    Lottie.loadAnimation({
       container: lottieAnimation.current,
-      animationData: animation,
+      ...options,
     });
   }, []);
 

--- a/components/Landing/LottieAnimation.tsx
+++ b/components/Landing/LottieAnimation.tsx
@@ -2,27 +2,15 @@ import Lottie from "lottie-web";
 import { Box } from "@chakra-ui/react";
 import React, { createRef, useEffect } from "react";
 
-export default function LottieAnimation(props) {
+export default function LottieAnimation({ animation, ...props }) {
   let lottieAnimation = createRef<HTMLDivElement>();
 
   useEffect(() => {
     const animate = Lottie.loadAnimation({
       container: lottieAnimation.current,
-      animationData: props.animation,
+      animationData: animation,
     });
   }, []);
 
-  return (
-    <Box
-      pos={props.pos}
-      top={props.top}
-      width={props.width}
-      height={props.height}
-      margin={props.margin}
-      minWidth={props.minWidth}
-      className={props.className}
-      alignSelf={props.alignSelf}
-      ref={lottieAnimation}
-    ></Box>
-  );
+  return <Box {...props} ref={lottieAnimation}></Box>;
 }

--- a/components/Profile/CompanyModal/CompanyModal.tsx
+++ b/components/Profile/CompanyModal/CompanyModal.tsx
@@ -32,7 +32,8 @@ import { DID } from "dids";
 import { IDX } from "@ceramicstudio/idx";
 import { TileDocument } from "@ceramicnetwork/stream-tile";
 import UserPermissionsRestricted from "../../UserPermissionsProvider/UserPermissionsRestricted";
-
+import { functionalExpertiseList } from "../../../utils/functionalExpertiseConstants";
+import { industryExpertiseList } from "../../../utils/industryExpertiseConstants";
 export interface Identity {
   firstName: string;
   lastName: string;
@@ -561,48 +562,9 @@ const CompanyModal = (props) => {
                       name="funcExpertise"
                       onChange={handleChange}
                     >
-                      <option>Accounting</option>
-                      <option>Creative</option>
-                      <option>Audit</option>
-                      <option>Board & Advisory</option>
-                      <option>Corporate Development</option>
-                      <option>Comp & Benefits</option>
-                      <option>Compliance</option>
-                      <option>Management Consulting</option>
-                      <option>Data & Analytics</option>
-                      <option>Product Design</option>
-                      <option>Digital</option>
-                      <option>Engineering</option>
-                      <option>Entrepreneurship</option>
-                      <option>Finance</option>
-                      <option>General Management</option>
-                      <option>Human Resources</option>
-                      <option>IT Infrastructure</option>
-                      <option>Innovation</option>
-                      <option>Investor</option>
-                      <option>Legal</option>
-                      <option>Marketing</option>
-                      <option>Media & Comms</option>
-                      <option>Merchandising</option>
-                      <option>Security</option>
-                      <option>Operations</option>
-                      <option>Portfolio Operations</option>
-                      <option>Procurement</option>
-                      <option>Product Management</option>
-                      <option>Investor Relations</option>
-                      <option>Regulatory</option>
-                      <option>Research</option>
-                      <option>Risk</option>
-                      <option>Strategy</option>
-                      <option>Technology</option>
-                      <option>Transformation</option>
-                      <option>Sales & Customer</option>
-                      <option>Data Science</option>
-                      <option>Talent Acquisition</option>
-                      <option>Tax</option>
-                      <option>Cybersecurity</option>
-                      <option>Investment Banking</option>
-                      <option>Supply Chain</option>
+                      {functionalExpertiseList.map((item, idx) => {
+                        return <option key={`&{item}--${idx}`}>{item}</option>;
+                      })}
                     </Select>
                   </FormControl>
                   <FormControl p={2} id="company-industry">
@@ -615,50 +577,9 @@ const CompanyModal = (props) => {
                       name="industryExpertise"
                       onChange={handleChange}
                     >
-                      <option>Accounting</option>
-                      <option>Angel Investment</option>
-                      <option>Asset Management</option>
-                      <option>Auto Insurance</option>
-                      <option>Banking</option>
-                      <option>Bitcoin</option>
-                      <option>Commercial Insurance</option>
-                      <option>Commercial Lending</option>
-                      <option>Credit</option>
-                      <option>Credit Bureau</option>
-                      <option>Credit Cards</option>
-                      <option>Crowdfunding</option>
-                      <option>Cryptocurrency</option>
-                      <option>Debit Cards</option>
-                      <option>Debt Collections</option>
-                      <option>Finance</option>
-                      <option>Financial Exchanges</option>
-                      <option>Financial Services</option>
-                      <option>FinTech</option>
-                      <option>Fraud Detection</option>
-                      <option>Funding Platform</option>
-                      <option>Gift Card</option>
-                      <option>Health Insurance</option>
-                      <option>Hedge Funds</option>
-                      <option>Impact Investing</option>
-                      <option>Incubators</option>
-                      <option>Insurance</option>
-                      <option>InsurTech</option>
-                      <option>Leasing</option>
-                      <option>Lending</option>
-                      <option>Life Insurance</option>
-                      <option>Micro Lending</option>
-                      <option>Mobile Payments</option>
-                      <option>Payments</option>
-                      <option>Personal Finance</option>
-                      <option>Prediction Markets</option>
-                      <option>Property Insurance</option>
-                      <option>Real Estate Investment</option>
-                      <option>Stock Exchanges</option>
-                      <option>Trading Platform</option>
-                      <option>Transaction Processing</option>
-                      <option>Venture Capital</option>
-                      <option>Virtual Currency</option>
-                      <option>Wealth Management</option>
+                      {industryExpertiseList.map((item, idx) => {
+                        return <option key={`&{item}--${idx}`}>{item}</option>;
+                      })}
                     </Select>
                   </FormControl>
                 </form>

--- a/components/Profile/CompanyModal/CompanyModal.tsx
+++ b/components/Profile/CompanyModal/CompanyModal.tsx
@@ -80,8 +80,8 @@ const CompanyModal = (props) => {
   const finalRef = useRef();
   const [count, setCount] = useState(0);
   const [isSubmitted, setIsSubmitted] = useState(false);
-  const [companyName, setCompanyName] = useState("");
-  const [companyTitle, setCompanyTitle] = useState("");
+  const [companyName, setCompanyName] = useState();
+  const [companyTitle, setCompanyTitle] = useState();
   const [companyStart, setCompanyStart] = useState();
   const [companyEnd, setCompanyEnd] = useState();
   const [companyFunction, setCompanyFunction] = useState();
@@ -89,7 +89,7 @@ const CompanyModal = (props) => {
   const [tempLogo, setTempLogo] = useState<any>();
   const [shouldFetch, setShouldFetch] = useState(false);
   const [isDisabled, setIsDisabled] = useState(false);
-  const [accType, setAccType] = useState(props.profileData.content.accType);
+  const [accType, setAccType] = useState();
   const [identity, setIdentity] = useState(props.profileData.content.identity);
   const emptyCompanyInfo = {
     companyName: "",
@@ -100,9 +100,11 @@ const CompanyModal = (props) => {
     companyIndustry: "",
   };
 
+  // on open, set the values to the current company
   useEffect(() => {
     if (!props.isOpen) return;
-    console.log("OPEN");
+    setAccType(props.profileData.content.accType);
+    setIdentity(props.profileData.content.identity);
     setCompanyName(
       props.profileData?.content?.identity?.companyInfo[props.currCompany]
         ?.companyName
@@ -121,11 +123,11 @@ const CompanyModal = (props) => {
     );
     setCompanyFunction(
       props.profileData?.content?.identity?.companyInfo[props.currCompany]
-        ?.funcExpertise
+        ?.companyFunc
     );
     setCompanyIndustry(
       props.profileData?.content?.identity?.companyInfo[props.currCompany]
-        ?.industryExpertise
+        ?.companyExpertise
     );
     setTempLogo(
       props.profileData?.content?.identity?.companyInfo[props.currCompany]?.logo
@@ -157,11 +159,9 @@ const CompanyModal = (props) => {
     companyEnd:
       companyInfo && companyInfo.companyEnd ? companyInfo.companyEnd : "",
     companyFunction:
-      companyInfo && companyInfo.companyFunction
-        ? companyInfo.companyFunction
-        : "",
+      companyInfo && companyInfo.companyFunc ? companyInfo.companyFunc : "",
     companyIndustry:
-      companyInfo && companyInfo.companyIndustry
+      companyInfo && companyInfo.industryExpertise
         ? companyInfo.companyIndustry
         : "",
   });

--- a/components/Profile/CompanyModal/CompanyModal.tsx
+++ b/components/Profile/CompanyModal/CompanyModal.tsx
@@ -1,4 +1,4 @@
-import { useContext, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   Box,
   HStack,
@@ -77,6 +77,7 @@ const endpoint = "https://ceramic-clay.3boxlabs.com";
 
 const CompanyModal = (props) => {
   const finalRef = useRef();
+  const [count, setCount] = useState(0);
   const [isSubmitted, setIsSubmitted] = useState(false);
   const [companyName, setCompanyName] = useState("");
   const [companyTitle, setCompanyTitle] = useState("");
@@ -97,6 +98,38 @@ const CompanyModal = (props) => {
     companyFunction: "",
     companyIndustry: "",
   };
+
+  useEffect(() => {
+    if (!props.isOpen) return;
+    console.log("OPEN");
+    setCompanyName(
+      props.profileData?.content?.identity?.companyInfo[props.currCompany]
+        ?.companyName
+    );
+    setCompanyTitle(
+      props.profileData?.content?.identity?.companyInfo[props.currCompany]
+        ?.companyTitle
+    );
+    setCompanyStart(
+      props.profileData?.content?.identity?.companyInfo[props.currCompany]
+        ?.companyStart
+    );
+    setCompanyEnd(
+      props.profileData?.content?.identity?.companyInfo[props.currCompany]
+        ?.companyEnd
+    );
+    setCompanyFunction(
+      props.profileData?.content?.identity?.companyInfo[props.currCompany]
+        ?.funcExpertise
+    );
+    setCompanyIndustry(
+      props.profileData?.content?.identity?.companyInfo[props.currCompany]
+        ?.industryExpertise
+    );
+    setTempLogo(
+      props.profileData?.content?.identity?.companyInfo[props.currCompany]?.logo
+    );
+  }, [props.isOpen]);
 
   const companyInfo =
     props.profileData.content.identity.companyInfo &&
@@ -199,7 +232,7 @@ const CompanyModal = (props) => {
         props.handleUpdatedCompanyInfo(props.profileData, false);
         props.setProfileData(newProfileData);
         props.onClose();
-        setTempLogo(false);
+
         setShouldFetch(false);
       } else {
         console.log("No profile, pls create one...");
@@ -356,7 +389,6 @@ const CompanyModal = (props) => {
             colorScheme="blue"
             mr={3}
             onClick={() => {
-              setTempLogo(false);
               props.onClose();
               setShouldFetch(false);
             }}
@@ -374,7 +406,6 @@ const CompanyModal = (props) => {
         finalFocusRef={finalRef}
         isOpen={props.isOpen}
         onClose={() => {
-          setTempLogo(false);
           props.onClose();
           setShouldFetch(false);
         }}
@@ -638,7 +669,6 @@ const CompanyModal = (props) => {
                 colorScheme="blue"
                 mr={3}
                 onClick={() => {
-                  setTempLogo(false);
                   props.onClose();
                   setShouldFetch(false);
                 }}

--- a/components/Profile/Components/MultiSelect.tsx
+++ b/components/Profile/Components/MultiSelect.tsx
@@ -1,6 +1,6 @@
 import { Button, FormControl, FormLabel, Select } from "@chakra-ui/react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 
 export function MultiSelect({
   formLabel,
@@ -10,26 +10,26 @@ export function MultiSelect({
   defaultValues,
   maxSelections,
 }) {
-  let defaults = [];
   // maxDisplayIndex tracks the index of the last element in the array that contains data
-  let maxDisplayIndex = 0;
+  const [maxDisplayIndex, setMaxDisplayIndex] = useState(0);
   const [count, setCount] = useState(maxDisplayIndex + 1 || 1);
 
-  for (let i = 0; i < defaultValues.length; i++) {
-    const element = defaultValues[i];
-    if (element !== "" && element !== null && element !== undefined) {
-      defaults.push(element);
-      if (i >= maxDisplayIndex) maxDisplayIndex = i;
+  useEffect(() => {
+    let defaults = [];
+    for (let i = 0; i < defaultValues.length; i++) {
+      const element = defaultValues[i];
+
+      if (element !== "" && element !== null && element !== undefined) {
+        defaults.push(element);
+        if (i >= maxDisplayIndex) {
+          setMaxDisplayIndex(i + 1);
+          setCount(i + 1);
+        }
+      }
     }
-  }
+  }, [count]);
 
   const splitLabel = name.split(/(?=[A-Z])/);
-
-  function handleAddSelector() {
-    if (count < maxSelections) {
-      setCount(count + 1);
-    }
-  }
 
   function createSelectors() {
     let selectors = [];
@@ -50,6 +50,11 @@ export function MultiSelect({
       selectors.push(element);
     }
     return selectors;
+  }
+  function handleAddSelector() {
+    if (count < maxSelections) {
+      setCount(count + 1);
+    }
   }
 
   return (

--- a/components/Profile/Components/MultiSelect.tsx
+++ b/components/Profile/Components/MultiSelect.tsx
@@ -2,7 +2,7 @@ import { Button, FormControl, FormLabel, Select } from "@chakra-ui/react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import React, { useState } from "react";
 
-export function MulitSelect({
+export function MultiSelect({
   formLabel,
   name,
   handleChange,
@@ -11,7 +11,10 @@ export function MulitSelect({
   maxSelections,
 }) {
   let defaults = [];
+  // maxDisplayIndex tracks the index of the last element in the array that contains data
   let maxDisplayIndex = 0;
+  const [count, setCount] = useState(maxDisplayIndex + 1 || 1);
+
   for (let i = 0; i < defaultValues.length; i++) {
     const element = defaultValues[i];
     if (element !== "" && element !== null && element !== undefined) {
@@ -20,12 +23,16 @@ export function MulitSelect({
     }
   }
 
-  let [count, setCount] = useState(maxDisplayIndex + 1 || 1);
-  let splitLabel = name.split(/(?=[A-Z])/);
+  const splitLabel = name.split(/(?=[A-Z])/);
+
+  function handleAddSelector() {
+    if (count < maxSelections) {
+      setCount(count + 1);
+    }
+  }
 
   function createSelectors() {
     let selectors = [];
-
     for (let i = 1; i <= maxSelections; i++) {
       const element = (
         <>
@@ -40,17 +47,11 @@ export function MulitSelect({
           )}
         </>
       );
-
       selectors.push(element);
     }
     return selectors;
   }
 
-  function handleAddSelector() {
-    if (count < maxSelections) {
-      setCount(count + 1);
-    }
-  }
   return (
     <>
       <FormControl p={4} id={`${splitLabel[0]}-${splitLabel[1]}`} isRequired>

--- a/components/Profile/EditExperienceModal/EditExperienceModal.tsx
+++ b/components/Profile/EditExperienceModal/EditExperienceModal.tsx
@@ -235,11 +235,7 @@ const EditExperienceModal = (props) => {
                   errorBorderColor="red.300"
                   placeholder="Display name"
                   name="displayName"
-                  defaultValue={
-                    values.displayName ||
-                    props.profileData.content.identity.displayName ||
-                    ""
-                  }
+                  defaultValue={values.displayName || ""}
                   onChange={handleChange}
                 />
                 {errors.displayName &&
@@ -261,11 +257,7 @@ const EditExperienceModal = (props) => {
                   errorBorderColor="red.300"
                   placeholder="Email"
                   name="email"
-                  defaultValue={
-                    values.email ||
-                    props.profileData.content.identity.email ||
-                    ""
-                  }
+                  defaultValue={values.email || ""}
                   onChange={handleChange}
                 />
                 {errors.email &&

--- a/components/Profile/EditExperienceModal/EditExperienceModal.tsx
+++ b/components/Profile/EditExperienceModal/EditExperienceModal.tsx
@@ -23,7 +23,7 @@ import { EthereumAuthProvider, ThreeIdConnect } from "@3id/connect";
 import { DID } from "dids";
 import { IDX } from "@ceramicstudio/idx";
 import { TileDocument } from "@ceramicnetwork/stream-tile";
-import { MulitSelect } from "../Components/MulitSelect";
+import { MultiSelect } from "../Components/MultiSelect";
 import { functionalExpertiseList } from "../../../utils/functionalExpertiseConstants";
 import { industryExpertiseList } from "../../../utils/industryExpertiseConstants";
 import { setEventArray } from "../helpers/setEventArray";
@@ -120,14 +120,6 @@ const EditExperienceModal = (props) => {
       ceramic.setDID(did);
       await ceramic.did.authenticate();
 
-      const idx = new IDX({ ceramic });
-
-      // does not require signing to get user's public data
-      const data: BasicProfile = await idx.get(
-        "basicProfile",
-        `${address}@eip155:1`
-      );
-
       await updateProfileData(ceramic, identity, accType);
 
       console.log("Profile updated!");
@@ -191,7 +183,7 @@ const EditExperienceModal = (props) => {
       strippedEventName === "industryExpertise"
     ) {
       // the stripped event name should be the same as the name of the state variable that should be changed for setEventArray to function properly
-      setEventArray(evt, setValues, values, setIdentity, identity);
+      setEventArray({ evt, setValues, values, setIdentity, identity });
     } else {
       setValues((values) => ({
         ...values,
@@ -267,7 +259,7 @@ const EditExperienceModal = (props) => {
                     </Text>
                   )}
               </FormControl>
-              <MulitSelect
+              <MultiSelect
                 formLabel={"So...what would you say you do?"}
                 name={"functionalExpertise"}
                 handleChange={handleChange}
@@ -278,7 +270,7 @@ const EditExperienceModal = (props) => {
                 }
                 maxSelections={3}
               />
-              <MulitSelect
+              <MultiSelect
                 formLabel={"Where would you say you work?"}
                 name={"industryExpertise"}
                 handleChange={handleChange}

--- a/components/Profile/EditExperienceModal/EditExperienceModal.tsx
+++ b/components/Profile/EditExperienceModal/EditExperienceModal.tsx
@@ -236,7 +236,9 @@ const EditExperienceModal = (props) => {
                   placeholder="Display name"
                   name="displayName"
                   defaultValue={
-                    props.profileData.content.identity.displayName || ""
+                    values.displayName ||
+                    props.profileData.content.identity.displayName ||
+                    ""
                   }
                   onChange={handleChange}
                 />
@@ -259,7 +261,11 @@ const EditExperienceModal = (props) => {
                   errorBorderColor="red.300"
                   placeholder="Email"
                   name="email"
-                  defaultValue={props.profileData.content.identity.email || ""}
+                  defaultValue={
+                    values.email ||
+                    props.profileData.content.identity.email ||
+                    ""
+                  }
                   onChange={handleChange}
                 />
                 {errors.email &&
@@ -275,6 +281,7 @@ const EditExperienceModal = (props) => {
                 handleChange={handleChange}
                 options={functionalExpertiseList}
                 defaultValues={
+                  values.functionalExpertise ||
                   props.profileData.content.identity.functionalExpertise
                 }
                 maxSelections={3}
@@ -285,6 +292,7 @@ const EditExperienceModal = (props) => {
                 handleChange={handleChange}
                 options={industryExpertiseList}
                 defaultValues={
+                  values.industryExpertise ||
                   props.profileData.content.identity.industryExpertise
                 }
                 maxSelections={3}

--- a/components/Profile/EditProfileModal/EditProfileModal.tsx
+++ b/components/Profile/EditProfileModal/EditProfileModal.tsx
@@ -88,6 +88,7 @@ const EditProfileModal = (props) => {
     firstName: props.profileData.content.identity.firstName,
     lastName: props.profileData.content.identity.lastName,
     currTitle: props.profileData.content.identity.currTitle,
+    currLocation: props.profileData.content.identity.currLocation,
     bio: props.profileData.content.identity.bio,
     linkedIn: props.profileData.content.identity.linkedIn,
     twitter: props.profileData.content.identity.twitter,
@@ -263,11 +264,7 @@ const EditProfileModal = (props) => {
                   errorBorderColor="red.300"
                   placeholder="First name"
                   name="firstName"
-                  defaultValue={
-                    identity.firstName ||
-                    props.profileData.content.identity.firstName ||
-                    ""
-                  }
+                  defaultValue={identity.firstName || ""}
                   onChange={handleChange}
                 />
                 {errors.firstName &&
@@ -290,11 +287,7 @@ const EditProfileModal = (props) => {
                   errorBorderColor="red.300"
                   placeholder="Last name"
                   name="lastName"
-                  defaultValue={
-                    identity.lastName ||
-                    props.profileData.content.identity.lastName ||
-                    ""
-                  }
+                  defaultValue={identity.lastName || ""}
                   onChange={handleChange}
                 />
                 {errors.lastName &&
@@ -315,11 +308,7 @@ const EditProfileModal = (props) => {
                   }
                   required
                   errorBorderColor="red.300"
-                  defaultValue={
-                    identity.currTitle ||
-                    props.profileData.content.identity.currTitle ||
-                    ""
-                  }
+                  defaultValue={identity.currTitle || ""}
                   name="currTitle"
                   onChange={handleChange}
                 />
@@ -334,12 +323,7 @@ const EditProfileModal = (props) => {
               <FormControl p={2} id="currLocation" isRequired>
                 <FormLabel>Where do you call home?</FormLabel>
                 <Select
-                  defaultValue={
-                    identity.currLocation ||
-                    props.profileData.content.identity.currLocation
-                      ? props.profileData.content.identity.currLocation
-                      : ""
-                  }
+                  defaultValue={identity.currLocation || ""}
                   placeholder="Select current location"
                   name="currLocation"
                   onChange={handleChange}
@@ -352,9 +336,7 @@ const EditProfileModal = (props) => {
                 <Textarea
                   isInvalid={errors.bio}
                   errorBorderColor="red.300"
-                  defaultValue={
-                    identity.bio || props.profileData.content.identity.bio || ""
-                  }
+                  defaultValue={identity.bio || ""}
                   name="bio"
                   maxLength={280}
                   onChange={handleChange}
@@ -371,11 +353,7 @@ const EditProfileModal = (props) => {
                   isInvalid={errors.linkedIn}
                   errorBorderColor="red.300"
                   name="linkedIn"
-                  defaultValue={
-                    identity.linkedIn ||
-                    props.profileData.content.identity.linkedIn ||
-                    ""
-                  }
+                  defaultValue={identity.linkedIn || ""}
                   onChange={handleChange}
                 />
                 {errors.linkedIn && (
@@ -390,11 +368,7 @@ const EditProfileModal = (props) => {
                   isInvalid={errors.twitter}
                   errorBorderColor="red.300"
                   name="twitter"
-                  defaultValue={
-                    identity.twitter ||
-                    props.profileData.content.identity.twitter ||
-                    ""
-                  }
+                  defaultValue={identity.twitter || ""}
                   onChange={handleChange}
                 />
                 {errors.twitter && (

--- a/components/Profile/EditProfileModal/EditProfileModal.tsx
+++ b/components/Profile/EditProfileModal/EditProfileModal.tsx
@@ -264,7 +264,9 @@ const EditProfileModal = (props) => {
                   placeholder="First name"
                   name="firstName"
                   defaultValue={
-                    props.profileData.content.identity.firstName || ""
+                    identity.firstName ||
+                    props.profileData.content.identity.firstName ||
+                    ""
                   }
                   onChange={handleChange}
                 />
@@ -289,7 +291,9 @@ const EditProfileModal = (props) => {
                   placeholder="Last name"
                   name="lastName"
                   defaultValue={
-                    props.profileData.content.identity.lastName || ""
+                    identity.lastName ||
+                    props.profileData.content.identity.lastName ||
+                    ""
                   }
                   onChange={handleChange}
                 />
@@ -312,7 +316,9 @@ const EditProfileModal = (props) => {
                   required
                   errorBorderColor="red.300"
                   defaultValue={
-                    props.profileData.content.identity.currTitle || ""
+                    identity.currTitle ||
+                    props.profileData.content.identity.currTitle ||
+                    ""
                   }
                   name="currTitle"
                   onChange={handleChange}
@@ -329,6 +335,7 @@ const EditProfileModal = (props) => {
                 <FormLabel>Where do you call home?</FormLabel>
                 <Select
                   defaultValue={
+                    identity.currLocation ||
                     props.profileData.content.identity.currLocation
                       ? props.profileData.content.identity.currLocation
                       : ""
@@ -345,7 +352,9 @@ const EditProfileModal = (props) => {
                 <Textarea
                   isInvalid={errors.bio}
                   errorBorderColor="red.300"
-                  defaultValue={props.profileData.content.identity.bio || ""}
+                  defaultValue={
+                    identity.bio || props.profileData.content.identity.bio || ""
+                  }
                   name="bio"
                   maxLength={280}
                   onChange={handleChange}
@@ -363,7 +372,9 @@ const EditProfileModal = (props) => {
                   errorBorderColor="red.300"
                   name="linkedIn"
                   defaultValue={
-                    props.profileData.content.identity.linkedIn || ""
+                    identity.linkedIn ||
+                    props.profileData.content.identity.linkedIn ||
+                    ""
                   }
                   onChange={handleChange}
                 />
@@ -380,7 +391,9 @@ const EditProfileModal = (props) => {
                   errorBorderColor="red.300"
                   name="twitter"
                   defaultValue={
-                    props.profileData.content.identity.twitter || ""
+                    identity.twitter ||
+                    props.profileData.content.identity.twitter ||
+                    ""
                   }
                   onChange={handleChange}
                 />

--- a/components/Profile/EditProfileModal/EditProfileModal.tsx
+++ b/components/Profile/EditProfileModal/EditProfileModal.tsx
@@ -125,14 +125,6 @@ const EditProfileModal = (props) => {
       ceramic.setDID(did);
       await ceramic.did.authenticate();
 
-      const idx = new IDX({ ceramic });
-
-      // does not require signing to get user's public data
-      const data: BasicProfile = await idx.get(
-        "basicProfile",
-        `${address}@eip155:1`
-      );
-
       if (fileUploaded) {
         // await idx.merge('basicProfile', { image: '💻' })
         console.log(fileUploaded);
@@ -166,7 +158,6 @@ const EditProfileModal = (props) => {
     const profileData = await TileDocument.deterministic(ceramic, {
       family: "user-profile-data",
     });
-
     await profileData.update({ identity, accType });
   };
 
@@ -178,12 +169,6 @@ const EditProfileModal = (props) => {
       ...identity,
       [evt.target.name]: evt.target.value,
     });
-    const newProfileData: ProfileData = {
-      content: {
-        identity: identity,
-        accType: props.profileData.content.accType,
-      },
-    };
   };
 
   const handleFile = (fileUploaded) => {

--- a/components/Profile/Profile.tsx
+++ b/components/Profile/Profile.tsx
@@ -482,11 +482,7 @@ const ProfilePage = () => {
                   <Stack spacing={6}>
                     <HStack>
                       <Text fontSize="xl">
-                        {profileData?.content?.identity?.firstName +
-                          " " +
-                          profileData?.content?.identity?.lastName +
-                          ", " +
-                          profileData.content.accType}
+                        {`${profileData?.content?.identity?.firstName} ${profileData?.content?.identity?.lastName}, ${profileData.content.accType}`}
                       </Text>
                       <FontAwesomeIcon size="lg" icon={["fas", "map-pin"]} />
                       {profileData.content.identity.currLocation && (

--- a/components/Profile/Profile.tsx
+++ b/components/Profile/Profile.tsx
@@ -129,10 +129,6 @@ const ProfilePage = () => {
 
     try {
       // does not require signing to get user's public data
-      const data: BasicProfile = await idx.get(
-        "basicProfile",
-        `${address}@eip155:1`
-      );
 
       const profile: ProfileData = await TileDocument.deterministic(
         ceramic,
@@ -140,7 +136,6 @@ const ProfilePage = () => {
         { anchor: false, publish: false }
       );
 
-      if (data.name) setName(data.name);
       if (profile) {
         setProfileData(profile);
       }
@@ -170,19 +165,12 @@ const ProfilePage = () => {
       await ceramic.did.authenticate();
 
       try {
-        // does not require signing to get user's public data
-        const data: BasicProfile = await idx.get(
-          "basicProfile",
-          `${address}@eip155:1`
-        );
-
         const profile: ProfileData = await TileDocument.deterministic(
           ceramic,
           { family: "user-profile-data" },
           { anchor: false, publish: false }
         );
 
-        if (data.name) setName(data.name);
         if (profile) {
           setProfileData(profile);
         }
@@ -372,7 +360,6 @@ const ProfilePage = () => {
         </VStack>
       ) : (
         profileData &&
-        name &&
         profileData.content &&
         profileData.content.accType &&
         profileData.content.identity && (
@@ -495,7 +482,11 @@ const ProfilePage = () => {
                   <Stack spacing={6}>
                     <HStack>
                       <Text fontSize="xl">
-                        {name + ", " + profileData.content.accType}
+                        {profileData?.content?.identity?.firstName +
+                          " " +
+                          profileData?.content?.identity?.lastName +
+                          ", " +
+                          profileData.content.accType}
                       </Text>
                       <FontAwesomeIcon size="lg" icon={["fas", "map-pin"]} />
                       {profileData.content.identity.currLocation && (

--- a/components/Profile/helpers/setEventArray.tsx
+++ b/components/Profile/helpers/setEventArray.tsx
@@ -1,3 +1,20 @@
+//                                                    _
+//         (:)_
+//         ,'    `.
+//        :        :
+//        |        |              ___
+//        |       /|    ______   // _\
+//        ; -  _,' :  ,'      `. \\  -\
+//       /          \/          \ \\  :
+//      (            :  ------.  `-'  |
+//   ____\___    ____|______   \______|_______
+//           |::|           '--`
+//           |::|
+//           |::|
+//           |::|
+//           |::;
+//           `:/
+//
 // sets new values & identity for the corresponding event in an array
 // requires an event with event.target.name == <stateName><number> e.g. "industryExpertise2" or "functionalExpertise1"
 // (e.g. values/identity = {bio: "",
@@ -8,7 +25,13 @@
 //                       -> strippedEventName = [...eventArray]
 // })
 
-export function setEventArray(evt, setValues, values, setIdentity, identity) {
+export function setEventArray({
+  evt,
+  setValues,
+  values,
+  setIdentity,
+  identity,
+}) {
   const eventName = evt.target.name;
   const [strippedEventName, eventIndex] = [
     eventName.substring(0, eventName.length - 1),

--- a/components/Profile/helpers/setEventArray.tsx
+++ b/components/Profile/helpers/setEventArray.tsx
@@ -32,6 +32,7 @@ export function setEventArray({
   setIdentity,
   identity,
 }) {
+  if (!evt) return;
   const eventName = evt.target.name;
   const [strippedEventName, eventIndex] = [
     eventName.substring(0, eventName.length - 1),

--- a/components/SignUpSteps/SignUpSteps.tsx
+++ b/components/SignUpSteps/SignUpSteps.tsx
@@ -1,4 +1,4 @@
-import { MulitSelect } from "../Profile/Components/MulitSelect";
+import { MultiSelect } from "../Profile/Components/MultiSelect";
 import { useState } from "react";
 import { Step, Steps, useSteps } from "chakra-ui-steps";
 import { connect } from "../../utils/walletUtils";
@@ -370,7 +370,7 @@ const professionalProfileStep = ({ handleChange, values, errors }) => {
                 {listOfCountries()}
               </Select>
             </FormControl>
-            <MulitSelect
+            <MultiSelect
               name={"functionalExpertise"}
               formLabel={"Functional expertise"}
               handleChange={handleChange}
@@ -378,7 +378,7 @@ const professionalProfileStep = ({ handleChange, values, errors }) => {
               options={functionalExpertiseList}
               maxSelections={3}
             />
-            <MulitSelect
+            <MultiSelect
               name={"industryExpertise"}
               formLabel={"Industry expertise"}
               handleChange={handleChange}
@@ -484,7 +484,7 @@ const SignUpSteps = () => {
       strippedEventName === "industryExpertise"
     ) {
       // the stripped event name should be the same as the name of the state variable that should be changed for setEventArray to function properly
-      setEventArray(evt, setValues, values, setIdentity, identity);
+      setEventArray({ evt, setValues, values, setIdentity, identity });
     } else {
       setValues((values) => ({
         ...values,

--- a/components/SignUpSteps/SignUpSteps.tsx
+++ b/components/SignUpSteps/SignUpSteps.tsx
@@ -379,9 +379,9 @@ const professionalProfileStep = ({ handleChange, values, errors }) => {
               maxSelections={3}
             />
             <MulitSelect
-              name={"industry expertise"}
+              name={"industryExpertise"}
+              formLabel={"Industry expertise"}
               handleChange={handleChange}
-              formLabel={"IndustryExpertise"}
               defaultValues={[]}
               options={industryExpertiseList}
               maxSelections={3}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,5 +1,4 @@
 /// <reference types="next" />
-/// <reference types="next/types/global" />
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -74,7 +74,7 @@ const IndexPage = () => {
                 alignSelf={"center"}
                 height={["36px", "48px", "65px"]}
                 width={["36px", "48px", "65.36px"]}
-                animation={handAnimation}
+                options={{ animationData: handAnimation }}
               />
             </HStack>
             <HStack alignItems={"baseline"}>
@@ -204,7 +204,7 @@ const IndexPage = () => {
                 width={"100%"}
                 height={"auto"}
                 minWidth={"100% !important"}
-                animation={bodyAnimation}
+                options={{ animationData: bodyAnimation }}
               />
             </VStack>
             <Flex


### PR DESCRIPTION
### What changes were made?

- Fixed mismatched state bug within the profile modals

### Is there any background info about the change?

- Will ensure users can't save incorrect information

### Are there any state changes? Mention key ones (if any)

No new states

States for company modal are now set on open to respective attribute within props.profileData.content.identity 

### Screenshots or Gifs✨

### Any new dependencies? Why were they added?

- none

### Shortcut Link

https://app.shortcut.com/twali/story/488/switch-default-values-in-modals-from-props-profiledata-to-values-identity
