### PR TITLE
Steps redesign

### DIFF
--- a/components/HeaderNav/HeaderNav.tsx
+++ b/components/HeaderNav/HeaderNav.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 import { Flex, HStack, Text, Img } from "@chakra-ui/react";
 
 const HeaderNav = (props) => {
@@ -23,29 +23,31 @@ const HeaderNav = (props) => {
         src="/twali-assets/navbar_logo.png"
       />
       <HStack alignItems="center" w="130px" height={"32px"}>
-        <Flex
-          ml="2"
-          mt="1"
-          width={"100%"}
-          height={"100%"}
-          border={"1px solid #F9FFF2"}
-          alignItems={"center"}
-          justifyItems={"center"}
-          borderRadius={32}
-        >
-          <Text
-            color="white"
-            fontSize={"14px"}
-            margin={"auto"}
-            alignSelf={"center"}
-            fontWeight={"700"}
-            letterSpacing={"0.06em"}
-            textTransform={"uppercase"}
-            isTruncated
+        {userWallet && (
+          <Flex
+            ml="2"
+            mt="1"
+            width={"100%"}
+            height={"100%"}
+            border={"1px solid #F9FFF2"}
+            alignItems={"center"}
+            justifyItems={"center"}
+            borderRadius={32}
           >
-            {userWallet}
-          </Text>
-        </Flex>
+            <Text
+              color="white"
+              fontSize={"14px"}
+              margin={"auto"}
+              alignSelf={"center"}
+              fontWeight={"700"}
+              letterSpacing={"0.06em"}
+              textTransform={"uppercase"}
+              isTruncated
+            >
+              {userWallet}
+            </Text>
+          </Flex>
+        )}
       </HStack>
     </Flex>
   );

--- a/components/HeaderNav/HeaderNav.tsx
+++ b/components/HeaderNav/HeaderNav.tsx
@@ -14,6 +14,7 @@ const HeaderNav = (props) => {
       justify="space-between"
       wrap="wrap"
       w="100%"
+      pos={props.step == 0 ? "absolute" : "relative"}
       backgroundColor={whichPage === "profile" ? "#0A1313" : "transparent"}
     >
       <Img

--- a/components/HeaderNav/HeaderNav.tsx
+++ b/components/HeaderNav/HeaderNav.tsx
@@ -3,7 +3,7 @@ import { Flex, HStack, Text, Img } from "@chakra-ui/react";
 
 const HeaderNav = (props) => {
   const whichPage = props.whichPage;
-
+  const userWallet = props.userWallet;
   return (
     <Flex
       height={"80px"}
@@ -40,8 +40,9 @@ const HeaderNav = (props) => {
             fontWeight={"700"}
             letterSpacing={"0.06em"}
             textTransform={"uppercase"}
+            isTruncated
           >
-            0xb794f...
+            {userWallet}
           </Text>
         </Flex>
       </HStack>

--- a/components/Profile/CompanyModal/CompanyModal.tsx
+++ b/components/Profile/CompanyModal/CompanyModal.tsx
@@ -86,7 +86,7 @@ const CompanyModal = (props) => {
 
   // on open, set the values to the current company
   useEffect(() => {
-    if (!props.isOpen) return;
+    if (!props.isOpen || !props.userData?.companyInfo) return;
     setCompanyName(props.userData?.companyInfo[props.currCompany]?.companyName);
     setCompanyTitle(
       props.userData?.companyInfo[props.currCompany]?.companyTitle
@@ -102,11 +102,11 @@ const CompanyModal = (props) => {
       props.userData?.companyInfo[props.currCompany]?.companyExpertise
     );
     setTempLogo(
-      props.userData?.companyInfo[props.currCompany].companyName
+      props.userData?.companyInfo[props.currCompany]?.companyName
         ? props.userData?.companyInfo[props.currCompany]?.logo
         : false
     );
-    console.log(props.userData?.companyInfo[props.currCompany].companyName);
+    console.log(props.userData?.companyInfo[props.currCompany]?.companyName);
   }, [props.isOpen]);
 
   const companyInfo =

--- a/components/Profile/Components/MultiSelect.tsx
+++ b/components/Profile/Components/MultiSelect.tsx
@@ -72,7 +72,7 @@ export function MultiSelect({
 
   return (
     <>
-      <FormControl p={4} id={`${splitLabel[0]}-${splitLabel[1]}`} isRequired>
+      <FormControl p={2} id={`${splitLabel[0]}-${splitLabel[1]}`} isRequired>
         <FormLabel
           pos={"relative"}
           left={"1px"}
@@ -130,7 +130,8 @@ function Selector({ splitLabel, handleChange, options, idx, defaultValue }) {
       defaultValue={defaultValue}
       errorBorderColor="red.300"
       fontFamily={"PP Telegraf light"}
-      color="#98B2B2"
+      color="white"
+      _placeholder={{ color: "#98B2B2" }}
     >
       {options?.map((option, idx) => {
         return <option key={`${option}--option-${idx}`}>{option}</option>;

--- a/components/Profile/Components/MultiSelect.tsx
+++ b/components/Profile/Components/MultiSelect.tsx
@@ -120,17 +120,26 @@ export function MultiSelect({
 }
 
 function Selector({ splitLabel, handleChange, options, idx, defaultValue }) {
+  const [color, setColor] = useState("#98B2B2");
   return (
     <Select
       key={`${splitLabel[0]}-${idx}`}
       marginTop={"8px"}
       placeholder={`Select ${splitLabel[0]} ${splitLabel[1]}`}
       name={`${splitLabel[0]}${splitLabel[1] + idx}`}
-      onChange={handleChange}
+      onChange={(e) => {
+        handleChange;
+        console.log(e.target.value);
+        if (e.target.value) {
+          setColor("#F9FFF2");
+        } else {
+          setColor("#98B2B2");
+        }
+      }}
       defaultValue={defaultValue}
       errorBorderColor="red.300"
       fontFamily={"PP Telegraf light"}
-      color="white"
+      color={color}
       _placeholder={{ color: "#98B2B2" }}
     >
       {options?.map((option, idx) => {

--- a/components/Profile/Components/MultiSelect.tsx
+++ b/components/Profile/Components/MultiSelect.tsx
@@ -128,7 +128,7 @@ function Selector({ splitLabel, handleChange, options, idx, defaultValue }) {
       placeholder={`Select ${splitLabel[0]} ${splitLabel[1]}`}
       name={`${splitLabel[0]}${splitLabel[1] + idx}`}
       onChange={(e) => {
-        handleChange;
+        handleChange(e);
         if (e.target.value) {
           setColor("#F9FFF2");
         } else {
@@ -138,7 +138,7 @@ function Selector({ splitLabel, handleChange, options, idx, defaultValue }) {
       defaultValue={defaultValue}
       errorBorderColor="red.300"
       fontFamily={"PP Telegraf light"}
-      color={color}
+      color={defaultValue ? "#F9FFF2" : "#98B2B2"}
       _placeholder={{ color: "#98B2B2" }}
     >
       {options?.map((option, idx) => {

--- a/components/Profile/Components/MultiSelect.tsx
+++ b/components/Profile/Components/MultiSelect.tsx
@@ -129,7 +129,6 @@ function Selector({ splitLabel, handleChange, options, idx, defaultValue }) {
       name={`${splitLabel[0]}${splitLabel[1] + idx}`}
       onChange={(e) => {
         handleChange;
-        console.log(e.target.value);
         if (e.target.value) {
           setColor("#F9FFF2");
         } else {

--- a/components/Profile/Components/MultiSelect.tsx
+++ b/components/Profile/Components/MultiSelect.tsx
@@ -1,4 +1,12 @@
-import { Button, FormControl, FormLabel, Select } from "@chakra-ui/react";
+import {
+  Button,
+  FormControl,
+  FormLabel,
+  HStack,
+  Img,
+  Select,
+  Text,
+} from "@chakra-ui/react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import React, { useEffect, useState } from "react";
 
@@ -9,6 +17,7 @@ export function MultiSelect({
   options,
   defaultValues,
   maxSelections,
+  ...props
 }) {
   // maxDisplayIndex tracks the index of the last element in the array that contains data
   const [maxDisplayIndex, setMaxDisplayIndex] = useState(0);
@@ -38,20 +47,7 @@ export function MultiSelect({
     for (let i = 1; i <= count; i++) {
       const element = (
         <>
-          {defaultValues ? (
-            (defaultValues[i - 1] || i === 1 || count >= i) && (
-              <Selector
-                key={`${i}--selector`}
-                splitLabel={splitLabel}
-                handleChange={handleChange}
-                options={options}
-                idx={i}
-                defaultValue={
-                  defaultValues?.length ? defaultValues[i - 1] : null
-                }
-              />
-            )
-          ) : (
+          {defaultValues && (defaultValues[i - 1] || i === 1 || count >= i) && (
             <Selector
               key={`${i}--selector`}
               splitLabel={splitLabel}
@@ -77,11 +73,45 @@ export function MultiSelect({
   return (
     <>
       <FormControl p={4} id={`${splitLabel[0]}-${splitLabel[1]}`} isRequired>
-        <FormLabel>{formLabel}</FormLabel>
+        <FormLabel
+          pos={"relative"}
+          left={"1px"}
+          fontFamily={"PP Telegraf"}
+          fontSize={"16px"}
+          fontStyle={"normal"}
+          fontWeight={"400"}
+          lineHeight={"24p"}
+          letterSpacing={"0.02em"}
+          textAlign={"left"}
+        >
+          {formLabel}
+        </FormLabel>
         {createSelectors()}
         {count !== maxSelections ? (
-          <Button marginTop={"10px"} onClick={handleAddSelector}>
-            <FontAwesomeIcon icon={"plus-circle"}></FontAwesomeIcon>
+          <Button
+            backgroundColor={"transparent"}
+            marginTop={"16px"}
+            onClick={handleAddSelector}
+            paddingLeft={"0"}
+          >
+            <HStack>
+              <Img
+                borderRadius="full"
+                backgroundColor="transparent"
+                width="32px"
+                src="twali-assets/plusicon.png"
+                alt="add img"
+              />
+              <Text
+                fontFamily={"PP Telegraf Light"}
+                fontWeight={"400"}
+                color={"#C7F83C"}
+                fontSize={"16px"}
+                lineHeight={"24px"}
+              >
+                Add expertise
+              </Text>
+            </HStack>
           </Button>
         ) : null}
       </FormControl>
@@ -98,6 +128,9 @@ function Selector({ splitLabel, handleChange, options, idx, defaultValue }) {
       name={`${splitLabel[0]}${splitLabel[1] + idx}`}
       onChange={handleChange}
       defaultValue={defaultValue}
+      errorBorderColor="red.300"
+      fontFamily={"PP Telegraf light"}
+      color="#98B2B2"
     >
       {options?.map((option, idx) => {
         return <option key={`${option}--option-${idx}`}>{option}</option>;

--- a/components/Profile/EditExpertiseModal/EditExpertiseModal.tsx
+++ b/components/Profile/EditExpertiseModal/EditExpertiseModal.tsx
@@ -126,24 +126,28 @@ const EditExpertiseModal = (props) => {
           <ModalBody>
             <form style={{ alignSelf: "center" }}>
               <MultiSelect
-                formLabel={"So...what would you say you do?"}
                 name={"functionalExpertise"}
+                formLabel={"Functional expertise"}
                 handleChange={handleChange}
                 options={functionalExpertiseList}
+                maxSelections={3}
                 defaultValues={
                   values.functionalExpertise ||
-                  props.userData.functionalExpertise
+                  props.userData.functionalExpertise ||
+                  []
                 }
-                maxSelections={3}
               />
+
               <MultiSelect
-                formLabel={"Where would you say you work?"}
                 name={"industryExpertise"}
+                formLabel={"Industry expertise"}
                 handleChange={handleChange}
-                options={industryExpertiseList}
                 defaultValues={
-                  values.industryExpertise || props.userData.industryExpertise
+                  values.industryExpertise ||
+                  props.userData.industryExpertise ||
+                  []
                 }
+                options={industryExpertiseList}
                 maxSelections={3}
               />
             </form>

--- a/components/Profile/GetCompany.tsx
+++ b/components/Profile/GetCompany.tsx
@@ -1,0 +1,130 @@
+import { Box, Img, Text } from "@chakra-ui/react";
+import UserPermissionsRestricted from "../UserPermissionsProvider/UserPermissionsRestricted";
+
+export const GetCompany = (props) => {
+  return (
+    <>
+      {props.company?.logo?.message?.logo ? (
+        <Box
+          w="80px"
+          height="80px"
+          display="flex"
+          borderRadius="full"
+          alignItems="center"
+          justifyContent="center"
+          backgroundColor="rgb(222,222,222)"
+          overflow="hidden"
+          p={4}
+          key={`${props.companyName}--${props.currCompany}--box`}
+        >
+          <UserPermissionsRestricted to="view">
+            <Img
+              backgroundColor="rgb(222, 222, 0)"
+              backgroundImage={"twali-assets/bannerimage.png"}
+              bgSize={"contain"}
+              style={{ cursor: "pointer" }}
+              key={`${props.companyName}--${props.currCompany}`}
+              alignSelf="center"
+              src={props.company.logo.message.logo}
+              alt={props.companyName}
+              onClick={() => {
+                props.setCurrCompany(props.currCompany);
+                props.onCompanyModalOpen();
+              }}
+            />
+          </UserPermissionsRestricted>
+          <UserPermissionsRestricted to="edit">
+            <Img
+              backgroundColor="rgb(222, 222, 222)"
+              style={{ cursor: "pointer" }}
+              key={`${props.companyName}--${props.currCompany}`}
+              alignSelf="center"
+              src={props.company.logo.message.logo}
+              alt={props.companyName}
+              onMouseEnter={(e) => (e.currentTarget.src = "edit.svg")}
+              onMouseLeave={(e) =>
+                (e.currentTarget.src = props.company.logo.message.logo)
+              }
+              onClick={() => {
+                props.setCurrCompany(props.currCompany);
+                props.onCompanyModalOpen();
+              }}
+            />
+          </UserPermissionsRestricted>
+        </Box>
+      ) : props ? (
+        <Box
+          w="80px"
+          height="80px"
+          borderRadius="full"
+          backgroundColor="rgb(222, 222, 222)"
+          bgGradient={
+            "linear-gradient(136.3deg, #0DD5D1 -3.88%, #9350B3 84.78%)"
+          }
+          overflow="hidden"
+          p={4}
+          key={`${props.companyName}--${props.currCompany}--box`}
+          onMouseEnter={(e) => {
+            let addImg = e.currentTarget.children[0] as HTMLElement;
+            let compLogo = e.currentTarget.children[1] as HTMLElement;
+            addImg.style.display = "flex";
+            compLogo.style.display = "none";
+          }}
+          onMouseLeave={(e) => {
+            let addImg = e.currentTarget.children[0] as HTMLElement;
+            let compLogo = e.currentTarget.children[1] as HTMLElement;
+            addImg.style.display = "none";
+            compLogo.style.display = "flex";
+          }}
+          onClick={() => {
+            props.setCurrCompany(props.currCompany);
+            props.onCompanyModalOpen();
+          }}
+        >
+          <Img
+            backgroundColor="rgb(222, 222, 222)"
+            bgGradient={
+              "linear-gradient(136.3deg, #0DD5D1 -3.88%, #9350B3 84.78%)"
+            }
+            borderRadius="full"
+            style={{ cursor: "pointer" }}
+            key={`${props.companyName}--${props.currCompany}`}
+            alignSelf="center"
+            src="edit.svg"
+            alt="edit stock img"
+            display={"none"}
+          />
+          <Text
+            w={"full"}
+            h={"full"}
+            fontSize="4xl"
+            fontWeight="400"
+            display={"flex"}
+            color={"#F9FFF2"}
+            justifyContent={"center"}
+            alignItems={"center"}
+            fontFamily={"GrandSlang"}
+          >
+            {props.companyName[0].toUpperCase()}
+          </Text>
+        </Box>
+      ) : (
+        <>
+          <Img
+            key={`${props.currCompany}--empty-company-exp`}
+            borderRadius="full"
+            style={{ cursor: "pointer" }}
+            backgroundColor="transparent"
+            width="80px"
+            src="twali-assets/plusicon.png"
+            alt="add img"
+            onClick={() => {
+              props.setCurrCompany(props.currCompany);
+              props.onCompanyModalOpen();
+            }}
+          />
+        </>
+      )}
+    </>
+  );
+};

--- a/components/Profile/ProfileDetails.tsx
+++ b/components/Profile/ProfileDetails.tsx
@@ -268,7 +268,7 @@ const ProfileDetails = ({ user }) => {
         userData.userName &&
         userData.userWallet && (
           <>
-            <HeaderNav whichPage="profil" />
+            <HeaderNav whichPage="profile" />
             <Container
               maxW="100%"
               p={0}

--- a/components/Profile/ProfileDetails.tsx
+++ b/components/Profile/ProfileDetails.tsx
@@ -6,7 +6,6 @@ import {
   Box,
   Img,
   VStack,
-  Text,
   useDisclosure,
   Flex,
   Container,
@@ -23,6 +22,7 @@ import { fetchPermission } from "../../utils/profileUtils";
 import LoginPage from "../../pages/login";
 import HeaderNav from "../HeaderNav/HeaderNav";
 import { UserData } from "../../utils/interfaces";
+import { GetCompany } from "./GetCompany";
 
 const ProfileDetails = ({ user }) => {
   // Fallback for getStaticPaths, when fallback: true
@@ -209,7 +209,8 @@ const ProfileDetails = ({ user }) => {
     for (let i = 0; i < number; i++) {
       if (
         userData.companyInfo &&
-        i < totalLen && userData.companyInfo[i] &&
+        i < totalLen &&
+        userData.companyInfo[i] &&
         userData.companyInfo[i].companyName
       ) {
         elements.push(
@@ -224,7 +225,10 @@ const ProfileDetails = ({ user }) => {
         );
       } else {
         elements.push(
-          <UserPermissionsRestricted to="edit" key={`${i}--empty-company-usr-permission`}>
+          <UserPermissionsRestricted
+            to="edit"
+            key={`${i}--empty-company-usr-permission`}
+          >
             <Img
               borderRadius="full"
               style={{ cursor: "pointer" }}
@@ -326,132 +330,4 @@ const ProfileDetails = ({ user }) => {
     </>
   );
 };
-const GetCompany = (props) => {
-  return (
-    <>
-      {props.company?.logo?.message?.logo ? (
-        <Box
-          w="80px"
-          height="80px"
-          display="flex"
-          borderRadius="full"
-          alignItems="center"
-          justifyContent="center"
-          backgroundColor="rgb(222,222,222)"
-          overflow="hidden"
-          p={4}
-          key={`${props.companyName}--${props.currCompany}--box`}
-        >
-          <UserPermissionsRestricted to="view">
-            <Img
-              backgroundColor="rgb(222, 222, 0)"
-              backgroundImage={"twali-assets/bannerimage.png"}
-              bgSize={"contain"}
-              style={{ cursor: "pointer" }}
-              key={`${props.companyName}--${props.currCompany}`}
-              alignSelf="center"
-              src={props.company.logo.message.logo}
-              alt={props.companyName}
-              onClick={() => {
-                props.setCurrCompany(props.currCompany);
-                props.onCompanyModalOpen();
-              }}
-            />
-          </UserPermissionsRestricted>
-          <UserPermissionsRestricted to="edit">
-            <Img
-              backgroundColor="rgb(222, 222, 222)"
-              style={{ cursor: "pointer" }}
-              key={`${props.companyName}--${props.currCompany}`}
-              alignSelf="center"
-              src={props.company.logo.message.logo}
-              alt={props.companyName}
-              onMouseEnter={(e) => (e.currentTarget.src = "edit.svg")}
-              onMouseLeave={(e) =>
-                (e.currentTarget.src = props.company.logo.message.logo)
-              }
-              onClick={() => {
-                props.setCurrCompany(props.currCompany);
-                props.onCompanyModalOpen();
-              }}
-            />
-          </UserPermissionsRestricted>
-        </Box>
-      ) : props ? (
-        <Box
-          w="80px"
-          height="80px"
-          borderRadius="full"
-          backgroundColor="rgb(222, 222, 222)"
-          bgGradient={
-            "linear-gradient(136.3deg, #0DD5D1 -3.88%, #9350B3 84.78%)"
-          }
-          overflow="hidden"
-          p={4}
-          key={`${props.companyName}--${props.currCompany}--box`}
-          onMouseEnter={(e) => {
-            let addImg = e.currentTarget.children[0] as HTMLElement;
-            let compLogo = e.currentTarget.children[1] as HTMLElement;
-            addImg.style.display = "flex";
-            compLogo.style.display = "none";
-          }}
-          onMouseLeave={(e) => {
-            let addImg = e.currentTarget.children[0] as HTMLElement;
-            let compLogo = e.currentTarget.children[1] as HTMLElement;
-            addImg.style.display = "none";
-            compLogo.style.display = "flex";
-          }}
-          onClick={() => {
-            props.setCurrCompany(props.currCompany);
-            props.onCompanyModalOpen();
-          }}
-        >
-          <Img
-            backgroundColor="rgb(222, 222, 222)"
-            bgGradient={
-              "linear-gradient(136.3deg, #0DD5D1 -3.88%, #9350B3 84.78%)"
-            }
-            borderRadius="full"
-            style={{ cursor: "pointer" }}
-            key={`${props.companyName}--${props.currCompany}`}
-            alignSelf="center"
-            src="edit.svg"
-            alt="edit stock img"
-            display={"none"}
-          />
-          <Text
-            w={"full"}
-            h={"full"}
-            fontSize="4xl"
-            fontWeight="400"
-            display={"flex"}
-            color={"#F9FFF2"}
-            justifyContent={"center"}
-            alignItems={"center"}
-            fontFamily={"GrandSlang"}
-          >
-            {props.companyName[0].toUpperCase()}
-          </Text>
-        </Box>
-      ) : (
-        <>
-          <Img
-            key={`${props.currCompany}--empty-company-exp`}
-            borderRadius="full"
-            style={{ cursor: "pointer" }}
-            backgroundColor="transparent"
-            width="80px"
-            src="twali-assets/plusicon.png"
-            alt="add img"
-            onClick={() => {
-              props.setCurrCompany(props.currCompany);
-              props.onCompanyModalOpen();
-            }}
-          />
-        </>
-      )}
-    </>
-  );
-};
-
 export default ProfileDetails;

--- a/components/Profile/ProfileHeader.tsx
+++ b/components/Profile/ProfileHeader.tsx
@@ -53,6 +53,7 @@ export function ProfileHeader({ userName }) {
         textTransform={"uppercase"}
         pos={"relative"}
         top={"16px"}
+        visibility={"hidden"}
       >
         available to work
       </Text>

--- a/components/Profile/ProfileSnapshots.tsx
+++ b/components/Profile/ProfileSnapshots.tsx
@@ -33,8 +33,7 @@ export function ProfileSnapshots({
         letterSpacing={"wide"}
         fontFamily={"PP Telegraf Light"}
       >
-        How to earn badges content. this is how its done so go get it done haha
-        nice ok got it.
+        The badges you earn participating in web3 will appear below
       </Text>
       {snapshotData ? (
         <>

--- a/components/SignUpSteps/SignUpSteps.tsx
+++ b/components/SignUpSteps/SignUpSteps.tsx
@@ -105,6 +105,8 @@ const SignUpSteps = () => {
 
   const handleChange = (evt) => {
     evt.persist();
+    console.log(evt);
+
     let strippedEventName = evt.target.name.substring(
       0,
       evt.target.name.length - 1

--- a/components/SignUpSteps/SignUpSteps.tsx
+++ b/components/SignUpSteps/SignUpSteps.tsx
@@ -32,8 +32,10 @@ const userProfileStep = ({ handleChange, values, errors }) => {
   return (
     <form style={{ alignSelf: "start" }}>
       <Box
-        h="100%"
-        w="xl"
+        maxWidth={"496px"}
+        mx={0}
+        my={2}
+        h={"532px"}
         border="1px solid #587070"
         borderRadius="16px"
         overflow="hidden"
@@ -51,9 +53,27 @@ const userProfileStep = ({ handleChange, values, errors }) => {
             isTruncated
           >
             <HStack spacing={2}>
-              <FormControl p={2} id="first-name" isRequired>
-                <FormLabel>First name</FormLabel>
+              <FormControl p={2} mx={1} id="first-name" isRequired>
+                <FormLabel
+                  marginBottom={1}
+                  pos={"relative"}
+                  fontFamily={"PP Telegraf"}
+                  fontSize={"16px"}
+                  fontStyle={"normal"}
+                  fontWeight={"400"}
+                  lineHeight={"24p"}
+                  letterSpacing={"0.02em"}
+                  textAlign={"left"}
+                >
+                  First name
+                </FormLabel>
                 <Input
+                  px={2}
+                  fontSize="16px"
+                  borderColor={"#587070"}
+                  height={"40px"}
+                  borderRadius={"4px"}
+                  marginBottom={"12px"}
                   required
                   isInvalid={errors.firstName}
                   errorBorderColor="red.300"
@@ -70,9 +90,27 @@ const userProfileStep = ({ handleChange, values, errors }) => {
                   </Text>
                 )}
               </FormControl>
-              <FormControl p={2} id="last-name" isRequired>
-                <FormLabel>Last name</FormLabel>
+              <FormControl p={2} mx={1} id="last-name" isRequired>
+                <FormLabel
+                  marginBottom={1}
+                  pos={"relative"}
+                  fontFamily={"PP Telegraf"}
+                  fontSize={"16px"}
+                  fontStyle={"normal"}
+                  fontWeight={"400"}
+                  lineHeight={"24p"}
+                  letterSpacing={"0.02em"}
+                  textAlign={"left"}
+                >
+                  Last name
+                </FormLabel>
                 <Input
+                  px={2}
+                  fontSize="16px"
+                  borderColor={"#587070"}
+                  height={"40px"}
+                  borderRadius={"4px"}
+                  marginBottom={"12px"}
                   required
                   isInvalid={errors.lastName}
                   errorBorderColor="red.300"
@@ -90,13 +128,31 @@ const userProfileStep = ({ handleChange, values, errors }) => {
                 )}
               </FormControl>
             </HStack>
-            <FormControl p={2} id="display-name" isRequired>
-              <FormLabel>User name</FormLabel>
+            <FormControl p={2} mx={1} id="display-name" isRequired>
+              <FormLabel
+                marginBottom={1}
+                pos={"relative"}
+                fontFamily={"PP Telegraf"}
+                fontSize={"16px"}
+                fontStyle={"normal"}
+                fontWeight={"400"}
+                lineHeight={"24p"}
+                letterSpacing={"0.02em"}
+                textAlign={"left"}
+              >
+                Display name
+              </FormLabel>
               <Input
+                px={2}
+                fontSize="16px"
+                borderColor={"#587070"}
+                height={"40px"}
+                borderRadius={"4px"}
+                marginBottom={"12px"}
                 required
                 isInvalid={errors.userName}
                 errorBorderColor="red.300"
-                placeholder="User name"
+                placeholder="choose your unique name"
                 name="userName"
                 fontFamily={"PP Telegraf light"}
                 _placeholder={{ color: "#98B2B2" }}
@@ -109,9 +165,48 @@ const userProfileStep = ({ handleChange, values, errors }) => {
                 </Text>
               )}
             </FormControl>
-            <FormControl p={2} id="email" isRequired>
-              <FormLabel>Email</FormLabel>
+            <FormControl p={2} mx={1} id="email" isRequired>
+              <HStack
+                alignItems={"baseline"}
+                justifyContent={"space-between"}
+                marginBottom={0}
+              >
+                <FormLabel
+                  marginBottom={1}
+                  pos={"relative"}
+                  fontFamily={"PP Telegraf"}
+                  fontSize={"16px"}
+                  fontStyle={"normal"}
+                  fontWeight={"400"}
+                  lineHeight={"24p"}
+                  letterSpacing={"0.02em"}
+                  textAlign={"left"}
+                >
+                  Email
+                </FormLabel>
+
+                <FormLabel
+                  marginBottom={1} //styleName: Body/body12;
+                  fontFamily={"PP Telegraf Light"}
+                  fontSize={"12px"}
+                  fontStyle={"normal"}
+                  fontWeight={"300"}
+                  lineHeight={"16px"}
+                  letterSpacing={"0em"}
+                  textAlign={"left"}
+                  color={"#0DD5D1"}
+                  requiredIndicator={null}
+                >
+                  your email won’t be shared with others
+                </FormLabel>
+              </HStack>
               <Input
+                px={2}
+                fontSize="16px"
+                borderColor={"#587070"}
+                height={"40px"}
+                borderRadius={"4px"}
+                marginBottom={"12px"}
                 required
                 isInvalid={errors.email}
                 errorBorderColor="red.300"
@@ -129,9 +224,27 @@ const userProfileStep = ({ handleChange, values, errors }) => {
               )}
             </FormControl>
             <HStack spacing={2}>
-              <FormControl p={2} id="twitter">
-                <FormLabel>Twitter URL</FormLabel>
+              <FormControl p={2} mx={1} id="twitter">
+                <FormLabel
+                  marginBottom={1}
+                  pos={"relative"}
+                  fontFamily={"PP Telegraf"}
+                  fontSize={"16px"}
+                  fontStyle={"normal"}
+                  fontWeight={"400"}
+                  lineHeight={"24p"}
+                  letterSpacing={"0.02em"}
+                  textAlign={"left"}
+                >
+                  Twitter URL
+                </FormLabel>
                 <Input
+                  px={2}
+                  fontSize="16px"
+                  borderColor={"#587070"}
+                  height={"40px"}
+                  borderRadius={"4px"}
+                  marginBottom={"12px"}
                   placeholder="Twitter"
                   _placeholder={{ color: "#98B2B2" }}
                   fontFamily={"PP Telegraf Light"}
@@ -139,9 +252,27 @@ const userProfileStep = ({ handleChange, values, errors }) => {
                   onChange={handleChange}
                 />
               </FormControl>
-              <FormControl p={2} id="linkedin">
-                <FormLabel>LinkedIn URL</FormLabel>
+              <FormControl p={2} mx={1} id="linkedin">
+                <FormLabel
+                  marginBottom={1}
+                  pos={"relative"}
+                  fontFamily={"PP Telegraf"}
+                  fontSize={"16px"}
+                  fontStyle={"normal"}
+                  fontWeight={"400"}
+                  lineHeight={"24p"}
+                  letterSpacing={"0.02em"}
+                  textAlign={"left"}
+                >
+                  LinkedIn URL
+                </FormLabel>
                 <Input
+                  px={2}
+                  fontSize="16px"
+                  borderColor={"#587070"}
+                  height={"40px"}
+                  borderRadius={"4px"}
+                  marginBottom={"12px"}
                   placeholder="LinkedIn"
                   _placeholder={{ color: "#98B2B2" }}
                   fontFamily={"PP Telegraf Light"}
@@ -150,9 +281,21 @@ const userProfileStep = ({ handleChange, values, errors }) => {
                 />
               </FormControl>
             </HStack>
-            <FormControl p={2} pb={8} id="website">
+            <FormControl pt={2} pb={3} px={2} id="website">
               <Box display="flex" justifyContent="space-between">
-                <FormLabel>Your Website URL</FormLabel>
+                <FormLabel
+                  marginBottom={1}
+                  pos={"relative"}
+                  fontFamily={"PP Telegraf"}
+                  fontSize={"16px"}
+                  fontStyle={"normal"}
+                  fontWeight={"400"}
+                  lineHeight={"24p"}
+                  letterSpacing={"0.02em"}
+                  textAlign={"left"}
+                >
+                  Your Website URL
+                </FormLabel>
                 <Tooltip
                   placement="auto-start"
                   hasArrow
@@ -164,6 +307,11 @@ const userProfileStep = ({ handleChange, values, errors }) => {
                 </Tooltip>
               </Box>
               <Input
+                px={2}
+                fontSize="16px"
+                borderColor={"#587070"}
+                height={"40px"}
+                borderRadius={"4px"}
                 placeholder="Website URL"
                 _placeholder={{ color: "#98B2B2" }}
                 fontFamily={"PP Telegraf Light"}
@@ -179,15 +327,19 @@ const userProfileStep = ({ handleChange, values, errors }) => {
 };
 
 const merchantProfileStep = ({ handleChange, values, errors }) => {
+  const [selected, setSelected] = useState("");
+
   return (
     <form style={{ alignSelf: "start" }}>
       <Box
+        maxWidth={"496px"}
         h="100%"
         w="xl"
         borderWidth="1px"
         borderRadius="lg"
         overflow="hidden"
         cursor="pointer"
+        backgroundColor={"#041A19E5"}
       >
         <Box p="4">
           <Box
@@ -199,7 +351,19 @@ const merchantProfileStep = ({ handleChange, values, errors }) => {
           >
             <FormControl p={4} id="business-name" isRequired>
               <HStack display="flex" justifyContent="space-between">
-                <FormLabel>Business legal name</FormLabel>
+                <FormLabel
+                  marginBottom={1}
+                  pos={"relative"}
+                  fontFamily={"PP Telegraf"}
+                  fontSize={"16px"}
+                  fontStyle={"normal"}
+                  fontWeight={"400"}
+                  lineHeight={"24p"}
+                  letterSpacing={"0.02em"}
+                  textAlign={"left"}
+                >
+                  Business legal name
+                </FormLabel>
                 <Tooltip
                   placement="auto-start"
                   hasArrow
@@ -212,6 +376,12 @@ const merchantProfileStep = ({ handleChange, values, errors }) => {
                 </Tooltip>
               </HStack>
               <Input
+                px={4}
+                fontSize="16px"
+                borderColor={"#587070"}
+                height={"40px"}
+                borderRadius={"4px"}
+                marginBottom={"12px"}
                 required
                 isInvalid={errors.businessName}
                 errorBorderColor="red.300"
@@ -227,13 +397,22 @@ const merchantProfileStep = ({ handleChange, values, errors }) => {
                   {errors.businessName}
                 </Text>
               )}
-              <FormHelperText>
-                If you don't have a business name, please use your legal name
-              </FormHelperText>
             </FormControl>
             <FormControl p={4} id="business-type" isRequired>
               <HStack justifyContent="space-between">
-                <FormLabel>Business type</FormLabel>
+                <FormLabel
+                  marginBottom={1}
+                  pos={"relative"}
+                  fontFamily={"PP Telegraf"}
+                  fontSize={"16px"}
+                  fontStyle={"normal"}
+                  fontWeight={"400"}
+                  lineHeight={"24p"}
+                  letterSpacing={"0.02em"}
+                  textAlign={"left"}
+                >
+                  Business type
+                </FormLabel>
                 <Link
                   href="https://www.sba.gov/business-guide/launch-your-business/choose-business-structure"
                   target={"_blank"}
@@ -251,9 +430,13 @@ const merchantProfileStep = ({ handleChange, values, errors }) => {
                 </Link>
               </HStack>
               <Select
+                errorBorderColor="red.300"
+                fontFamily={"PP Telegraf Light"}
                 placeholder="Select business type"
+                iconColor={"#F9FFF2"}
                 name="businessType"
                 onChange={handleChange}
+                color={values.businessType ? "#F9FFF2" : "#98B2B2"}
               >
                 <option>Sole proprietorship</option>
                 <option>Partnership</option>
@@ -267,8 +450,22 @@ const merchantProfileStep = ({ handleChange, values, errors }) => {
                         )} */}
             </FormControl>
             <FormControl p={4} id="business-location" isRequired>
-              <FormLabel>Business location</FormLabel>
+              <FormLabel
+                marginBottom={1}
+                pos={"relative"}
+                fontFamily={"PP Telegraf"}
+                fontSize={"16px"}
+                fontStyle={"normal"}
+                fontWeight={"400"}
+                lineHeight={"24p"}
+                letterSpacing={"0.02em"}
+                textAlign={"left"}
+              >
+                Business location
+              </FormLabel>
               <Select
+                fontFamily={"PP Telegraf Light"}
+                color={values.businessLocation ? "#F9FFF2" : "#98B2B2"}
                 placeholder="Select business location"
                 name="businessLocation"
                 onChange={handleChange}
@@ -290,12 +487,14 @@ const professionalProfileStep = ({ handleChange, values, errors }) => {
   return (
     <form style={{ alignSelf: "start" }}>
       <Box
+        maxWidth={"496px"}
         h="100%"
         w="xl"
         borderWidth="1px"
         borderRadius="lg"
         overflow="hidden"
         cursor="pointer"
+        backgroundColor={"#041A19E5"}
       >
         <Box p="4">
           <Box
@@ -306,8 +505,26 @@ const professionalProfileStep = ({ handleChange, values, errors }) => {
             isTruncated
           >
             <FormControl p={4} id="current-company-title" isRequired>
-              <FormLabel>Current title</FormLabel>
+              <FormLabel
+                marginBottom={1}
+                pos={"relative"}
+                fontFamily={"PP Telegraf"}
+                fontSize={"16px"}
+                fontStyle={"normal"}
+                fontWeight={"400"}
+                lineHeight={"24p"}
+                letterSpacing={"0.02em"}
+                textAlign={"left"}
+              >
+                Current title
+              </FormLabel>
               <Input
+                px={2}
+                fontSize="16px"
+                borderColor={"#587070"}
+                height={"40px"}
+                borderRadius={"4px"}
+                marginBottom={"12px"}
                 isInvalid={errors.currTitle}
                 errorBorderColor="red.300"
                 fontFamily={"PP Telegraf light"}
@@ -325,8 +542,22 @@ const professionalProfileStep = ({ handleChange, values, errors }) => {
               )}
             </FormControl>
             <FormControl p={4} id="current-location">
-              <FormLabel>Current location</FormLabel>
+              <FormLabel
+                marginBottom={1}
+                pos={"relative"}
+                fontFamily={"PP Telegraf"}
+                fontSize={"16px"}
+                fontStyle={"normal"}
+                fontWeight={"400"}
+                lineHeight={"24p"}
+                letterSpacing={"0.02em"}
+                textAlign={"left"}
+              >
+                Current location
+              </FormLabel>
               <Select
+                color="#98B2B2"
+                fontFamily={"PP Telegraf Light"}
                 placeholder="Select current location"
                 name="currLocation"
                 onChange={handleChange}
@@ -708,7 +939,7 @@ const SignUpSteps = () => {
               </Step>
             ))}
           </Steps>
-          <HStack>
+          <HStack width={"100%"} justifyContent={"center"}>
             <Button
               w="sm"
               alignSelf="left"
@@ -734,7 +965,7 @@ const SignUpSteps = () => {
               textTransform={"uppercase"}
               backgroundColor={"#C7F83C"}
               onClick={() => {
-                if (activeStep > 2) {
+                if (activeStep > 1) {
                   updateAccType();
                 } else {
                   nextStep();

--- a/components/SignUpSteps/SignUpSteps.tsx
+++ b/components/SignUpSteps/SignUpSteps.tsx
@@ -1,597 +1,24 @@
-import { MultiSelect } from "../Profile/Components/MultiSelect";
+import { AccountSelection } from "./accountSelection";
 import { useState } from "react";
 import { Step, Steps, useSteps } from "chakra-ui-steps";
 import { connect } from "../../utils/walletUtils";
-import { listOfCountries } from "../../utils/profileUtils";
-
+import background from "../../public/twali-assets/backgroundscreen.png";
 import {
   Heading,
-  FormControl,
-  Input,
-  Box,
   Button,
-  FormLabel,
-  Select,
   HStack,
-  VStack,
   CircularProgress,
-  Text,
-  FormHelperText,
-  Tooltip,
-  Img,
-  Link,
+  Container,
+  Flex,
+  VStack,
 } from "@chakra-ui/react";
 import { useRouter } from "next/router";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { functionalExpertiseList } from "../../utils/functionalExpertiseConstants";
-import { industryExpertiseList } from "../../utils/industryExpertiseConstants";
 import { setEventArray } from "../Profile/helpers/setEventArray";
 import { UserData } from "../../utils/interfaces";
-
-const userProfileStep = ({ handleChange, values, errors }) => {
-  return (
-    <form style={{ alignSelf: "start" }}>
-      <Box
-        maxWidth={"496px"}
-        mx={0}
-        my={2}
-        h={"532px"}
-        border="1px solid #587070"
-        borderRadius="16px"
-        overflow="hidden"
-        cursor="pointer"
-        backgroundColor={"#041A19E5"}
-        fontFamily={"PP Telegraf"}
-        boxShadow={"8px 16px 24px 0px #062B2A8F"}
-      >
-        <Box p="4">
-          <Box
-            mt="1"
-            fontWeight="semibold"
-            as="h4"
-            lineHeight="tight"
-            isTruncated
-          >
-            <HStack spacing={2}>
-              <FormControl p={2} mx={1} id="first-name" isRequired>
-                <FormLabel
-                  marginBottom={1}
-                  pos={"relative"}
-                  fontFamily={"PP Telegraf"}
-                  fontSize={"16px"}
-                  fontStyle={"normal"}
-                  fontWeight={"400"}
-                  lineHeight={"24p"}
-                  letterSpacing={"0.02em"}
-                  textAlign={"left"}
-                >
-                  First name
-                </FormLabel>
-                <Input
-                  px={2}
-                  fontSize="16px"
-                  borderColor={"#587070"}
-                  height={"40px"}
-                  borderRadius={"4px"}
-                  marginBottom={"12px"}
-                  required
-                  isInvalid={errors.firstName}
-                  errorBorderColor="red.300"
-                  placeholder="First name"
-                  name="firstName"
-                  fontFamily={"PP Telegraf light"}
-                  _placeholder={{ color: "#98B2B2" }}
-                  value={values.firstName || ""}
-                  onChange={handleChange}
-                />
-                {errors.firstName && (
-                  <Text fontSize="xs" fontWeight="400" color="red.500">
-                    {errors.firstName}
-                  </Text>
-                )}
-              </FormControl>
-              <FormControl p={2} mx={1} id="last-name" isRequired>
-                <FormLabel
-                  marginBottom={1}
-                  pos={"relative"}
-                  fontFamily={"PP Telegraf"}
-                  fontSize={"16px"}
-                  fontStyle={"normal"}
-                  fontWeight={"400"}
-                  lineHeight={"24p"}
-                  letterSpacing={"0.02em"}
-                  textAlign={"left"}
-                >
-                  Last name
-                </FormLabel>
-                <Input
-                  px={2}
-                  fontSize="16px"
-                  borderColor={"#587070"}
-                  height={"40px"}
-                  borderRadius={"4px"}
-                  marginBottom={"12px"}
-                  required
-                  isInvalid={errors.lastName}
-                  errorBorderColor="red.300"
-                  placeholder="Last name"
-                  name="lastName"
-                  fontFamily={"PP Telegraf light"}
-                  _placeholder={{ color: "#98B2B2" }}
-                  value={values.lastName || ""}
-                  onChange={handleChange}
-                />
-                {errors.lastName && (
-                  <Text fontSize="xs" fontWeight="400" color="red.500">
-                    {errors.lastName}
-                  </Text>
-                )}
-              </FormControl>
-            </HStack>
-            <FormControl p={2} mx={1} id="display-name" isRequired>
-              <FormLabel
-                marginBottom={1}
-                pos={"relative"}
-                fontFamily={"PP Telegraf"}
-                fontSize={"16px"}
-                fontStyle={"normal"}
-                fontWeight={"400"}
-                lineHeight={"24p"}
-                letterSpacing={"0.02em"}
-                textAlign={"left"}
-              >
-                Display name
-              </FormLabel>
-              <Input
-                px={2}
-                fontSize="16px"
-                borderColor={"#587070"}
-                height={"40px"}
-                borderRadius={"4px"}
-                marginBottom={"12px"}
-                required
-                isInvalid={errors.userName}
-                errorBorderColor="red.300"
-                placeholder="choose your unique name"
-                name="userName"
-                fontFamily={"PP Telegraf light"}
-                _placeholder={{ color: "#98B2B2" }}
-                value={values.userName || ""}
-                onChange={handleChange}
-              />
-              {errors.userName && (
-                <Text fontSize="xs" fontWeight="400" color="red.500">
-                  {errors.userName}
-                </Text>
-              )}
-            </FormControl>
-            <FormControl p={2} mx={1} id="email" isRequired>
-              <HStack
-                alignItems={"baseline"}
-                justifyContent={"space-between"}
-                marginBottom={0}
-              >
-                <FormLabel
-                  marginBottom={1}
-                  pos={"relative"}
-                  fontFamily={"PP Telegraf"}
-                  fontSize={"16px"}
-                  fontStyle={"normal"}
-                  fontWeight={"400"}
-                  lineHeight={"24p"}
-                  letterSpacing={"0.02em"}
-                  textAlign={"left"}
-                >
-                  Email
-                </FormLabel>
-
-                <FormLabel
-                  marginBottom={1} //styleName: Body/body12;
-                  fontFamily={"PP Telegraf Light"}
-                  fontSize={"12px"}
-                  fontStyle={"normal"}
-                  fontWeight={"300"}
-                  lineHeight={"16px"}
-                  letterSpacing={"0em"}
-                  textAlign={"left"}
-                  color={"#0DD5D1"}
-                  requiredIndicator={null}
-                >
-                  your email won’t be shared with others
-                </FormLabel>
-              </HStack>
-              <Input
-                px={2}
-                fontSize="16px"
-                borderColor={"#587070"}
-                height={"40px"}
-                borderRadius={"4px"}
-                marginBottom={"12px"}
-                required
-                isInvalid={errors.email}
-                errorBorderColor="red.300"
-                placeholder="Email"
-                name="email"
-                fontFamily={"PP Telegraf light"}
-                _placeholder={{ color: "#98B2B2" }}
-                value={values.email || ""}
-                onChange={handleChange}
-              />
-              {errors.email && (
-                <Text fontSize="xs" fontWeight="400" color="red.500">
-                  {errors.email}
-                </Text>
-              )}
-            </FormControl>
-            <HStack spacing={2}>
-              <FormControl p={2} mx={1} id="twitter">
-                <FormLabel
-                  marginBottom={1}
-                  pos={"relative"}
-                  fontFamily={"PP Telegraf"}
-                  fontSize={"16px"}
-                  fontStyle={"normal"}
-                  fontWeight={"400"}
-                  lineHeight={"24p"}
-                  letterSpacing={"0.02em"}
-                  textAlign={"left"}
-                >
-                  Twitter URL
-                </FormLabel>
-                <Input
-                  px={2}
-                  fontSize="16px"
-                  borderColor={"#587070"}
-                  height={"40px"}
-                  borderRadius={"4px"}
-                  marginBottom={"12px"}
-                  placeholder="Twitter"
-                  _placeholder={{ color: "#98B2B2" }}
-                  fontFamily={"PP Telegraf Light"}
-                  name="twitter"
-                  onChange={handleChange}
-                />
-              </FormControl>
-              <FormControl p={2} mx={1} id="linkedin">
-                <FormLabel
-                  marginBottom={1}
-                  pos={"relative"}
-                  fontFamily={"PP Telegraf"}
-                  fontSize={"16px"}
-                  fontStyle={"normal"}
-                  fontWeight={"400"}
-                  lineHeight={"24p"}
-                  letterSpacing={"0.02em"}
-                  textAlign={"left"}
-                >
-                  LinkedIn URL
-                </FormLabel>
-                <Input
-                  px={2}
-                  fontSize="16px"
-                  borderColor={"#587070"}
-                  height={"40px"}
-                  borderRadius={"4px"}
-                  marginBottom={"12px"}
-                  placeholder="LinkedIn"
-                  _placeholder={{ color: "#98B2B2" }}
-                  fontFamily={"PP Telegraf Light"}
-                  name="linkedIn"
-                  onChange={handleChange}
-                />
-              </FormControl>
-            </HStack>
-            <FormControl pt={2} pb={3} px={2} id="website">
-              <Box display="flex" justifyContent="space-between">
-                <FormLabel
-                  marginBottom={1}
-                  pos={"relative"}
-                  fontFamily={"PP Telegraf"}
-                  fontSize={"16px"}
-                  fontStyle={"normal"}
-                  fontWeight={"400"}
-                  lineHeight={"24p"}
-                  letterSpacing={"0.02em"}
-                  textAlign={"left"}
-                >
-                  Your Website URL
-                </FormLabel>
-                <Tooltip
-                  placement="auto-start"
-                  hasArrow
-                  label="Add a personal or business website here"
-                >
-                  <Box pos="relative">
-                    <FontAwesomeIcon icon={"info-circle"} />
-                  </Box>
-                </Tooltip>
-              </Box>
-              <Input
-                px={2}
-                fontSize="16px"
-                borderColor={"#587070"}
-                height={"40px"}
-                borderRadius={"4px"}
-                placeholder="Website URL"
-                _placeholder={{ color: "#98B2B2" }}
-                fontFamily={"PP Telegraf Light"}
-                name="website"
-                onChange={handleChange}
-              />
-            </FormControl>
-          </Box>
-        </Box>
-      </Box>
-    </form>
-  );
-};
-
-const merchantProfileStep = ({ handleChange, values, errors }) => {
-  const [incorporated, setIncorporated] = useState(false);
-
-  return (
-    <form style={{ alignSelf: "start" }}>
-      <Box
-        maxWidth={"496px"}
-        h="100%"
-        w="xl"
-        borderWidth="1px"
-        borderRadius="lg"
-        overflow="hidden"
-        cursor="pointer"
-        backgroundColor={"#041A19E5"}
-      >
-        <Box p="4">
-          <Box
-            mt="1"
-            fontWeight="semibold"
-            as="h4"
-            lineHeight="tight"
-            isTruncated
-          >
-            <FormControl p={2} id="business-type" isRequired>
-              <HStack justifyContent="space-between">
-                <FormLabel
-                  marginBottom={1}
-                  pos={"relative"}
-                  fontFamily={"PP Telegraf"}
-                  fontSize={"16px"}
-                  fontStyle={"normal"}
-                  fontWeight={"400"}
-                  lineHeight={"24p"}
-                  letterSpacing={"0.02em"}
-                  textAlign={"left"}
-                >
-                  Business type
-                </FormLabel>
-                <Link
-                  href="https://www.sba.gov/business-guide/launch-your-business/choose-business-structure"
-                  target={"_blank"}
-                  rel="noopener noreferrer"
-                >
-                  <Tooltip
-                    placement="auto-start"
-                    hasArrow
-                    label="Click to learn more "
-                  >
-                    <Box pos="relative">
-                      <FontAwesomeIcon icon={"info-circle"} />
-                    </Box>
-                  </Tooltip>
-                </Link>
-              </HStack>
-              <Select
-                errorBorderColor="red.300"
-                fontFamily={"PP Telegraf Light"}
-                placeholder="Select business type"
-                iconColor={"#F9FFF2"}
-                name="businessType"
-                onChange={handleChange}
-                color={values.businessType ? "#F9FFF2" : "#98B2B2"}
-              >
-                <option>I'm not incorporated!</option>
-                <option>Sole proprietorship</option>
-                <option>Partnership</option>
-                <option>Corporation</option>
-                <option>Single-member LLC</option>
-                <option>LLC</option>
-                <option>Non-profit</option>
-              </Select>
-              {/* {errors.businessType && (
-                          <Text fontSize='xs' fontWeight='400' color='red.500'>{errors.businessType}</Text>
-                        )} */}
-            </FormControl>
-            <FormControl p={2} id="business-name" isRequired>
-              <HStack display="flex" justifyContent="space-between">
-                <FormLabel
-                  marginBottom={1}
-                  pos={"relative"}
-                  fontFamily={"PP Telegraf"}
-                  fontSize={"16px"}
-                  fontStyle={"normal"}
-                  fontWeight={"400"}
-                  lineHeight={"24p"}
-                  letterSpacing={"0.02em"}
-                  textAlign={"left"}
-                >
-                  Business legal name
-                </FormLabel>
-                <Tooltip
-                  placement="auto-start"
-                  hasArrow
-                  label="If you are a sole proprietor, partnership, or single-member LLC, your 'Business Name' may be registered as your personal name or your business’s DBA.
-                  If you are an LLC, corporation, or non-profit, Twali requires that the 'Business Name' be in the company’s legal business name or DBA"
-                >
-                  <Box pos="relative">
-                    <FontAwesomeIcon icon={"info-circle"} />
-                  </Box>
-                </Tooltip>
-              </HStack>
-              <Input
-                disabled={values.businessType === "I'm not incorporated!"}
-                px={4}
-                fontSize="16px"
-                borderColor={"#587070"}
-                height={"40px"}
-                borderRadius={"4px"}
-                marginBottom={"12px"}
-                required
-                isInvalid={errors.businessName}
-                errorBorderColor="red.300"
-                fontFamily={"PP Telegraf light"}
-                _placeholder={{ color: "#98B2B2" }}
-                value={values.businessName || ""}
-                placeholder="Business legal name"
-                name="businessName"
-                onChange={handleChange}
-              />
-              {errors.businessName && (
-                <Text fontSize="xs" fontWeight="400" color="red.500">
-                  {errors.businessName}
-                </Text>
-              )}
-            </FormControl>
-
-            <FormControl p={2} id="business-location" isRequired>
-              <FormLabel
-                marginBottom={1}
-                pos={"relative"}
-                fontFamily={"PP Telegraf"}
-                fontSize={"16px"}
-                fontStyle={"normal"}
-                fontWeight={"400"}
-                lineHeight={"24p"}
-                letterSpacing={"0.02em"}
-                textAlign={"left"}
-              >
-                Business location
-              </FormLabel>
-              <Select
-                fontFamily={"PP Telegraf Light"}
-                color={values.businessLocation ? "#F9FFF2" : "#98B2B2"}
-                placeholder="Select business location"
-                name="businessLocation"
-                onChange={handleChange}
-                disabled={values.businessType === "I'm not incorporated!"}
-              >
-                {listOfCountries()}
-              </Select>
-              {/* {errors.businessLocation && (
-                          <Text fontSize='xs' fontWeight='400' color='red.500'>{errors.businessType}</Text>
-                        )} */}
-            </FormControl>
-          </Box>
-        </Box>
-      </Box>
-    </form>
-  );
-};
-
-const professionalProfileStep = ({ handleChange, values, errors }) => {
-  return (
-    <form style={{ alignSelf: "start" }}>
-      <Box
-        maxWidth={"496px"}
-        h="100%"
-        w="xl"
-        borderWidth="1px"
-        borderRadius="lg"
-        overflow="hidden"
-        cursor="pointer"
-        backgroundColor={"#041A19E5"}
-      >
-        <Box p="4">
-          <Box
-            mt="1"
-            fontWeight="semibold"
-            as="h4"
-            lineHeight="tight"
-            isTruncated
-          >
-            <FormControl p={2} id="current-company-title" isRequired>
-              <FormLabel
-                marginBottom={1}
-                pos={"relative"}
-                fontFamily={"PP Telegraf"}
-                fontSize={"16px"}
-                fontStyle={"normal"}
-                fontWeight={"400"}
-                lineHeight={"24p"}
-                letterSpacing={"0.02em"}
-                textAlign={"left"}
-              >
-                Current title
-              </FormLabel>
-              <Input
-                px={2}
-                fontSize="16px"
-                borderColor={"#587070"}
-                height={"40px"}
-                borderRadius={"4px"}
-                marginBottom={"12px"}
-                isInvalid={errors.currTitle}
-                errorBorderColor="red.300"
-                fontFamily={"PP Telegraf light"}
-                _placeholder={{ color: "#98B2B2" }}
-                value={values.currTitle || ""}
-                required
-                placeholder="Current title"
-                name="currTitle"
-                onChange={handleChange}
-              />
-              {errors.currTitle && (
-                <Text fontSize="xs" fontWeight="400" color="red.500">
-                  {errors.currTitle}
-                </Text>
-              )}
-            </FormControl>
-            <FormControl p={2} id="current-location">
-              <FormLabel
-                marginBottom={1}
-                pos={"relative"}
-                fontFamily={"PP Telegraf"}
-                fontSize={"16px"}
-                fontStyle={"normal"}
-                fontWeight={"400"}
-                lineHeight={"24p"}
-                letterSpacing={"0.02em"}
-                textAlign={"left"}
-              >
-                Current location
-              </FormLabel>
-              <Select
-                color="#F9FFF2"
-                fontFamily={"PP Telegraf Light"}
-                placeholder="Select current location"
-                _placeholder={{ color: "#98B2B2 !important" }}
-                name="currLocation"
-                onChange={handleChange}
-              >
-                {listOfCountries()}
-              </Select>
-            </FormControl>
-            <MultiSelect
-              name={"functionalExpertise"}
-              formLabel={"Functional expertise"}
-              handleChange={handleChange}
-              defaultValues={[]}
-              options={functionalExpertiseList}
-              maxSelections={3}
-            />
-            <MultiSelect
-              name={"industryExpertise"}
-              formLabel={"Industry expertise"}
-              handleChange={handleChange}
-              defaultValues={[]}
-              options={industryExpertiseList}
-              maxSelections={3}
-            />
-          </Box>
-        </Box>
-      </Box>
-    </form>
-  );
-};
+import { userProfileStep } from "./userProfileStep";
+import { merchantProfileStep } from "./merchantProfileStep";
+import { professionalProfileStep } from "./professionalProfileStep";
+import HeaderNav from "../HeaderNav/HeaderNav";
 
 const SignUpSteps = () => {
   const router = useRouter();
@@ -752,244 +179,109 @@ const SignUpSteps = () => {
     setAccType(accType);
     setIsAccTypeSelected(true);
   };
-
+  const [accSelectionComplete, setAccSelectionComplete] = useState(false);
   // Either displaying the account type selection
   // Or the steps component based on user selection
   return (
     <>
-      {isAccTypeSelection ? (
-        <>
-          <Button
-            size="sm"
-            pl={40}
-            onClick={() => router.push("/login")}
-            colorScheme="gray"
-            variant="link"
-          >
-            Back
-          </Button>
-          <Heading alignSelf="center">Sign Up</Heading>
-
-          <VStack alignSelf="center" spacing={8}>
-            <Text
-              alignSelf="center"
-              color="rgb(255, 255, 255)"
-              fontWeight="semibold"
-              fontSize="sm"
-              p={0}
-              m={0}
-            >
-              How would you like to use Twali?
-            </Text>
-            <HStack>
-              <Box
-                display="flex"
-                flexDirection="column"
-                justifyContent="space-between"
-                w="sm"
-                h="200px"
-                borderWidth="1px"
-                borderRadius="lg"
-                borderColor={btnActive == 1 ? "gray.200" : "gray.500"}
-                overflow="hidden"
-                cursor="pointer"
-                onClick={() => {
-                  setBtnActive(1);
-                  selectUserAccType("Expert");
-                }}
-              >
-                <Box p="4">
-                  <Box
-                    mt="1"
-                    fontWeight="semibold"
-                    as="h4"
-                    lineHeight="tight"
-                    isTruncated
-                  >
-                    As an expert 🔑
-                  </Box>
-
-                  <Box>
-                    <Box as="span" color="gray.500" fontSize="sm">
-                      I want to provide my knowledge and expertise
-                    </Box>
-                  </Box>
-                </Box>
-                <Box
-                  display="flex"
-                  justifyContent="flex-end"
-                  w="100%"
-                  padding="1rem"
-                >
-                  <Box
-                    w="2rem"
-                    h="2rem"
-                    backgroundColor="white"
-                    borderRadius="50%"
-                    position="relative"
-                  >
-                    {btnActive == 1 ? (
-                      <Img
-                        backgroundColor="rgb(222, 222, 222)"
-                        w="2rem"
-                        borderRadius="50%"
-                        style={{ cursor: "pointer" }}
-                        alignSelf="center"
-                        src="check-mark.png"
-                        alt="check mark"
-                      />
-                    ) : (
-                      <Box
-                        w="2rem"
-                        h="2rem"
-                        backgroundColor="gray.200"
-                        borderRadius="50%"
-                        boxShadow="inset 0 0px 5px 0 rgba(0,0,0,.8)"
-                      ></Box>
-                    )}
-                  </Box>
-                </Box>
-              </Box>
-              <Box
-                display="flex"
-                flexDirection="column"
-                justifyContent="space-between"
-                w="sm"
-                h="200px"
-                borderWidth="1px"
-                borderRadius="lg"
-                borderColor={btnActive == 2 ? "gray.200" : "gray.500"}
-                overflow="hidden"
-                cursor="pointer"
-                onClick={() => {
-                  setBtnActive(2);
-                  selectUserAccType("Builder");
-                }}
-              >
-                <Box p="4">
-                  <Box
-                    mt="1"
-                    fontWeight="semibold"
-                    as="h4"
-                    lineHeight="tight"
-                    isTruncated
-                  >
-                    As a builder 🛠
-                  </Box>
-
-                  <Box>
-                    <Box as="span" color="gray.500" fontSize="sm">
-                      I want to build a project
-                    </Box>
-                  </Box>
-                </Box>
-                <Box
-                  display="flex"
-                  justifyContent="flex-end"
-                  w="100%"
-                  padding="1rem"
-                >
-                  {btnActive == 2 ? (
-                    <Img
-                      backgroundColor="rgb(222, 222, 222)"
-                      w="2rem"
-                      borderRadius="50%"
-                      style={{ cursor: "pointer" }}
-                      alignSelf="center"
-                      src="check-mark.png"
-                      alt="check mark"
-                    />
-                  ) : (
-                    <Box
-                      w="2rem"
-                      h="2rem"
-                      backgroundColor="gray.200"
-                      borderRadius="50%"
-                      boxShadow="inset 0 0px 5px 0 rgba(0,0,0,.8)"
-                    ></Box>
-                  )}
-                </Box>
-              </Box>
-            </HStack>
-          </VStack>
-          <Button
-            disabled={!isAccTypeSelected}
-            alignSelf="center"
-            backgroundColor={"#C7F83C"}
-            w="xl"
-            onClick={(evt) => {
-              setIsAccTypeSelection(false);
-            }}
-          >
-            Continue
-          </Button>
-        </>
-      ) : (
-        <>
-          <Heading
-            fontSize={"72px"}
-            lineHeight={"88px"}
-            marginTop={"24px"}
-            marginBottom={"-8px"}
-            alignSelf="flex-start"
-            fontFamily={"Scope Light"}
-            fontWeight={"400"}
-          >
-            Set up my Twali
-          </Heading>
-          <Steps activeStep={activeStep}>
-            {steps.map(({ label, content }) => (
-              <Step label={label} key={label}>
-                {content}
-              </Step>
-            ))}
-          </Steps>
-          <HStack width={"100%"} justifyContent={"center"}>
-            <Button
-              w="sm"
-              alignSelf="left"
-              onClick={() => {
-                activeStep <= 0 ? router.push("/login") : prevStep();
-              }}
-              backgroundColor={"transparent"}
-              border={"1px solid #C7F83C"}
-              height={"40px"}
-              borderRadius={"32px"}
-              alignItems={"center"}
-              textTransform={"uppercase"}
-              justifyContent={"center"}
-              variant="link"
-            >
-              go back
-            </Button>
-            <Button
-              w="sm"
-              alignSelf="center"
-              color={"#0A1313"}
-              borderRadius={"32px"}
-              textTransform={"uppercase"}
-              backgroundColor={"#C7F83C"}
-              onClick={() => {
-                if (activeStep > 1) {
-                  updateAccType();
-                } else {
-                  nextStep();
-                }
-              }}
-            >
-              continue
-              {isSubmitted ? (
-                <CircularProgress
-                  size="22px"
-                  thickness="4px"
-                  isIndeterminate
-                  color="#3C2E26"
+      <Container
+        width="100%"
+        minHeight="100vh"
+        maxW={"100%"}
+        pos={"relative"}
+        bgSize={"cover"}
+        bgPosition={"center"}
+        bgImg={`url(${background.src})`}
+        px={0}
+      >
+        <HeaderNav whichPage="steps" step={accSelectionComplete} />
+        <Container
+          maxW="container.xl"
+          pb={!accSelectionComplete ? "inherit" : 8}
+          px={0}
+          m={accSelectionComplete ? "inherit" : 0}
+        >
+          <Flex h="full">
+            <VStack w="full" h="full" spacing={8} alignItems="flex-start">
+              {isAccTypeSelection ? (
+                <AccountSelection
+                  btnActive={btnActive}
+                  setBtnActive={setBtnActive}
+                  selectUserAccType={selectUserAccType}
+                  isAccTypeSelected={isAccTypeSelected}
+                  setIsAccTypeSelection={setIsAccTypeSelection}
+                  setAccSelectionComplete={setAccSelectionComplete}
                 />
-              ) : null}
-            </Button>{" "}
-          </HStack>
-        </>
-      )}
+              ) : (
+                <>
+                  <Heading
+                    fontSize={"72px"}
+                    lineHeight={"88px"}
+                    marginTop={"24px"}
+                    marginBottom={"-8px"}
+                    alignSelf="flex-start"
+                    fontFamily={"Scope Light"}
+                    fontWeight={"400"}
+                  >
+                    Set up my Twali
+                  </Heading>
+                  <Steps activeStep={activeStep}>
+                    {steps.map(({ label, content }) => (
+                      <Step label={label} key={label}>
+                        {content}
+                      </Step>
+                    ))}
+                  </Steps>
+                  <HStack width={"100%"} justifyContent={"center"}>
+                    <Button
+                      w="sm"
+                      alignSelf="left"
+                      onClick={() => {
+                        activeStep <= 0 ? router.push("/login") : prevStep();
+                      }}
+                      backgroundColor={"transparent"}
+                      border={"1px solid #C7F83C"}
+                      height={"40px"}
+                      borderRadius={"32px"}
+                      alignItems={"center"}
+                      textTransform={"uppercase"}
+                      justifyContent={"center"}
+                      variant="link"
+                    >
+                      go back
+                    </Button>
+                    <Button
+                      w="sm"
+                      alignSelf="center"
+                      color={"#0A1313"}
+                      borderRadius={"32px"}
+                      textTransform={"uppercase"}
+                      backgroundColor={"#C7F83C"}
+                      onClick={() => {
+                        if (activeStep > 1) {
+                          updateAccType();
+                        } else {
+                          nextStep();
+                        }
+                      }}
+                    >
+                      continue
+                      {isSubmitted ? (
+                        <CircularProgress
+                          size="22px"
+                          thickness="4px"
+                          isIndeterminate
+                          color="#3C2E26"
+                        />
+                      ) : null}
+                    </Button>{" "}
+                  </HStack>
+                </>
+              )}
+            </VStack>
+          </Flex>
+        </Container>
+      </Container>
     </>
   );
 };

--- a/components/SignUpSteps/SignUpSteps.tsx
+++ b/components/SignUpSteps/SignUpSteps.tsx
@@ -327,7 +327,7 @@ const userProfileStep = ({ handleChange, values, errors }) => {
 };
 
 const merchantProfileStep = ({ handleChange, values, errors }) => {
-  const [selected, setSelected] = useState("");
+  const [incorporated, setIncorporated] = useState(false);
 
   return (
     <form style={{ alignSelf: "start" }}>
@@ -349,56 +349,7 @@ const merchantProfileStep = ({ handleChange, values, errors }) => {
             lineHeight="tight"
             isTruncated
           >
-            <FormControl p={4} id="business-name" isRequired>
-              <HStack display="flex" justifyContent="space-between">
-                <FormLabel
-                  marginBottom={1}
-                  pos={"relative"}
-                  fontFamily={"PP Telegraf"}
-                  fontSize={"16px"}
-                  fontStyle={"normal"}
-                  fontWeight={"400"}
-                  lineHeight={"24p"}
-                  letterSpacing={"0.02em"}
-                  textAlign={"left"}
-                >
-                  Business legal name
-                </FormLabel>
-                <Tooltip
-                  placement="auto-start"
-                  hasArrow
-                  label="If you are a sole proprietor, partnership, or single-member LLC, your 'Business Name' may be registered as your personal name or your business’s DBA.
-                  If you are an LLC, corporation, or non-profit, Twali requires that the 'Business Name' be in the company’s legal business name or DBA"
-                >
-                  <Box pos="relative">
-                    <FontAwesomeIcon icon={"info-circle"} />
-                  </Box>
-                </Tooltip>
-              </HStack>
-              <Input
-                px={4}
-                fontSize="16px"
-                borderColor={"#587070"}
-                height={"40px"}
-                borderRadius={"4px"}
-                marginBottom={"12px"}
-                required
-                isInvalid={errors.businessName}
-                errorBorderColor="red.300"
-                fontFamily={"PP Telegraf light"}
-                _placeholder={{ color: "#98B2B2" }}
-                value={values.businessName || ""}
-                placeholder="Business legal name"
-                name="businessName"
-                onChange={handleChange}
-              />
-              {errors.businessName && (
-                <Text fontSize="xs" fontWeight="400" color="red.500">
-                  {errors.businessName}
-                </Text>
-              )}
-            </FormControl>
-            <FormControl p={4} id="business-type" isRequired>
+            <FormControl p={2} id="business-type" isRequired>
               <HStack justifyContent="space-between">
                 <FormLabel
                   marginBottom={1}
@@ -438,6 +389,7 @@ const merchantProfileStep = ({ handleChange, values, errors }) => {
                 onChange={handleChange}
                 color={values.businessType ? "#F9FFF2" : "#98B2B2"}
               >
+                <option>I'm not incorporated!</option>
                 <option>Sole proprietorship</option>
                 <option>Partnership</option>
                 <option>Corporation</option>
@@ -449,7 +401,58 @@ const merchantProfileStep = ({ handleChange, values, errors }) => {
                           <Text fontSize='xs' fontWeight='400' color='red.500'>{errors.businessType}</Text>
                         )} */}
             </FormControl>
-            <FormControl p={4} id="business-location" isRequired>
+            <FormControl p={2} id="business-name" isRequired>
+              <HStack display="flex" justifyContent="space-between">
+                <FormLabel
+                  marginBottom={1}
+                  pos={"relative"}
+                  fontFamily={"PP Telegraf"}
+                  fontSize={"16px"}
+                  fontStyle={"normal"}
+                  fontWeight={"400"}
+                  lineHeight={"24p"}
+                  letterSpacing={"0.02em"}
+                  textAlign={"left"}
+                >
+                  Business legal name
+                </FormLabel>
+                <Tooltip
+                  placement="auto-start"
+                  hasArrow
+                  label="If you are a sole proprietor, partnership, or single-member LLC, your 'Business Name' may be registered as your personal name or your business’s DBA.
+                  If you are an LLC, corporation, or non-profit, Twali requires that the 'Business Name' be in the company’s legal business name or DBA"
+                >
+                  <Box pos="relative">
+                    <FontAwesomeIcon icon={"info-circle"} />
+                  </Box>
+                </Tooltip>
+              </HStack>
+              <Input
+                disabled={values.businessType === "I'm not incorporated!"}
+                px={4}
+                fontSize="16px"
+                borderColor={"#587070"}
+                height={"40px"}
+                borderRadius={"4px"}
+                marginBottom={"12px"}
+                required
+                isInvalid={errors.businessName}
+                errorBorderColor="red.300"
+                fontFamily={"PP Telegraf light"}
+                _placeholder={{ color: "#98B2B2" }}
+                value={values.businessName || ""}
+                placeholder="Business legal name"
+                name="businessName"
+                onChange={handleChange}
+              />
+              {errors.businessName && (
+                <Text fontSize="xs" fontWeight="400" color="red.500">
+                  {errors.businessName}
+                </Text>
+              )}
+            </FormControl>
+
+            <FormControl p={2} id="business-location" isRequired>
               <FormLabel
                 marginBottom={1}
                 pos={"relative"}
@@ -469,6 +472,7 @@ const merchantProfileStep = ({ handleChange, values, errors }) => {
                 placeholder="Select business location"
                 name="businessLocation"
                 onChange={handleChange}
+                disabled={values.businessType === "I'm not incorporated!"}
               >
                 {listOfCountries()}
               </Select>
@@ -504,7 +508,7 @@ const professionalProfileStep = ({ handleChange, values, errors }) => {
             lineHeight="tight"
             isTruncated
           >
-            <FormControl p={4} id="current-company-title" isRequired>
+            <FormControl p={2} id="current-company-title" isRequired>
               <FormLabel
                 marginBottom={1}
                 pos={"relative"}
@@ -541,7 +545,7 @@ const professionalProfileStep = ({ handleChange, values, errors }) => {
                 </Text>
               )}
             </FormControl>
-            <FormControl p={4} id="current-location">
+            <FormControl p={2} id="current-location">
               <FormLabel
                 marginBottom={1}
                 pos={"relative"}
@@ -556,9 +560,10 @@ const professionalProfileStep = ({ handleChange, values, errors }) => {
                 Current location
               </FormLabel>
               <Select
-                color="#98B2B2"
+                color="#F9FFF2"
                 fontFamily={"PP Telegraf Light"}
                 placeholder="Select current location"
+                _placeholder={{ color: "#98B2B2 !important" }}
                 name="currLocation"
                 onChange={handleChange}
               >
@@ -932,7 +937,7 @@ const SignUpSteps = () => {
           >
             Set up my Twali
           </Heading>
-          <Steps activeStep={activeStep} colorScheme="teal">
+          <Steps activeStep={activeStep}>
             {steps.map(({ label, content }) => (
               <Step label={label} key={label}>
                 {content}

--- a/components/SignUpSteps/SignUpSteps.tsx
+++ b/components/SignUpSteps/SignUpSteps.tsx
@@ -105,7 +105,6 @@ const SignUpSteps = () => {
 
   const handleChange = (evt) => {
     evt.persist();
-    console.log(evt);
 
     let strippedEventName = evt.target.name.substring(
       0,

--- a/components/SignUpSteps/SignUpSteps.tsx
+++ b/components/SignUpSteps/SignUpSteps.tsx
@@ -11,6 +11,7 @@ import {
   Container,
   Flex,
   VStack,
+  Text,
 } from "@chakra-ui/react";
 import { useRouter } from "next/router";
 import { setEventArray } from "../Profile/helpers/setEventArray";
@@ -232,26 +233,44 @@ const SignUpSteps = () => {
                       </Step>
                     ))}
                   </Steps>
-                  <HStack width={"100%"} justifyContent={"center"}>
+                  <HStack width={"100%"} justifyContent={"flex-end"}>
                     <Button
-                      w="sm"
+                      w="160px"
                       alignSelf="left"
+                      mr={"24px"}
                       onClick={() => {
                         activeStep <= 0 ? router.push("/login") : prevStep();
                       }}
                       backgroundColor={"transparent"}
-                      border={"1px solid #C7F83C"}
+                      border={"1px solid #98B2B2"}
                       height={"40px"}
+                      pos={"relative"}
+                      fontSize={"14px"}
+                      fontFamily={"PP Telegraf Bold"}
+                      letterSpacing={"0.06em;"}
                       borderRadius={"32px"}
                       alignItems={"center"}
                       textTransform={"uppercase"}
                       justifyContent={"center"}
                       variant="link"
                     >
-                      go back
+                      <Text
+                        display={"flex"}
+                        width={"100%"}
+                        height={"100%"}
+                        justifyContent={"center"}
+                        alignItems={"center"}
+                      >
+                        go back
+                      </Text>
                     </Button>
                     <Button
-                      w="sm"
+                      w="160px"
+                      height={"40px"}
+                      pos={"relative"}
+                      fontSize={"14px"}
+                      fontFamily={"PP Telegraf Bold"}
+                      letterSpacing={"0.06em;"}
                       alignSelf="center"
                       color={"#0A1313"}
                       borderRadius={"32px"}
@@ -265,7 +284,16 @@ const SignUpSteps = () => {
                         }
                       }}
                     >
-                      continue
+                      <Text
+                        display={"flex"}
+                        width={"100%"}
+                        height={"100%"}
+                        justifyContent={"center"}
+                        alignItems={"center"}
+                      >
+                        continue
+                      </Text>
+
                       {isSubmitted ? (
                         <CircularProgress
                           size="22px"

--- a/components/SignUpSteps/accountSelection.tsx
+++ b/components/SignUpSteps/accountSelection.tsx
@@ -18,7 +18,7 @@ export function AccountSelection({
       maxW={"100%"}
       width={"100%"}
       height={"100%"}
-      flexDir={"row"}
+      flexDir={["column", "column", "row"]}
       alignItems={"center"}
       minWidth={"100vw"}
       minHeight={"100vh"}
@@ -26,8 +26,8 @@ export function AccountSelection({
       <VStack
         m={0}
         p={0}
-        width={"50%"}
-        minH={"100vh"}
+        width={["100%", "100%", "50%"]}
+        minH={["90vh", "75vh", "100vh"]}
         height={"100%"}
         color={"black"}
         justifyContent={"center "}
@@ -96,8 +96,8 @@ export function AccountSelection({
       <VStack
         m={0}
         p={0}
-        width={"50%"}
-        minH={"100vh"}
+        width={["100%", "100%", "50%"]}
+        minH={["90vh", "75vh", "100vh"]}
         height={"100%"}
         justifyContent={"center "}
         backgroundSize={"cover"}

--- a/components/SignUpSteps/accountSelection.tsx
+++ b/components/SignUpSteps/accountSelection.tsx
@@ -1,4 +1,4 @@
-import { Text, VStack, Button, Flex } from "@chakra-ui/react";
+import { Text, VStack, Button, Flex, Link } from "@chakra-ui/react";
 import { useRouter } from "next/router";
 import React from "react";
 
@@ -105,7 +105,7 @@ export function AccountSelection({
         cursor="pointer"
         onClick={() => {
           setBtnActive(2);
-          selectUserAccType("Builder");
+          selectUserAccType("Client");
         }}
         backgroundImage={
           btnActive == 2
@@ -127,7 +127,7 @@ export function AccountSelection({
           color={btnActive == 2 ? "#0A1313" : "#C7F83C"}
           backgroundColor={btnActive == 2 ? "#C7F83C" : "#0A1313"}
         >
-          builder
+          client
         </Text>
         <Text
           pos={"relative"}
@@ -140,25 +140,27 @@ export function AccountSelection({
           I want to build a project
         </Text>
 
-        <Button
-          disabled={!isAccTypeSelected}
-          alignSelf="center"
-          backgroundColor={"#C7F83C"}
-          color={"#0A1313"}
-          w="220px"
-          h={"40px"}
-          pos={"relative"}
-          top={"200px"}
-          borderRadius={"32px"}
-          padding={"16px, 24px, 13px, 24px"}
-          onClick={(evt) => {
-            setIsAccTypeSelection(false);
-            setAccSelectionComplete(true);
-          }}
-          visibility={btnActive == 2 ? "unset" : "hidden"}
+        <Link
+          _hover={{ textDecoration: "none" }}
+          textDecoration={"none"}
+          href="mailto:degen@twali.xyz"
         >
-          Continue
-        </Button>
+          <Button
+            disabled={!isAccTypeSelected}
+            alignSelf="center"
+            backgroundColor={"#C7F83C"}
+            color={"#0A1313"}
+            w="220px"
+            h={"40px"}
+            pos={"relative"}
+            top={"200px"}
+            borderRadius={"32px"}
+            padding={"16px, 24px, 13px, 24px"}
+            visibility={btnActive == 2 ? "unset" : "hidden"}
+          >
+            Continue
+          </Button>
+        </Link>
       </VStack>
     </Flex>
   );

--- a/components/SignUpSteps/accountSelection.tsx
+++ b/components/SignUpSteps/accountSelection.tsx
@@ -1,0 +1,165 @@
+import { Text, VStack, Button, Flex } from "@chakra-ui/react";
+import { useRouter } from "next/router";
+import React from "react";
+
+export function AccountSelection({
+  btnActive,
+  setBtnActive,
+  selectUserAccType,
+  isAccTypeSelected,
+  setIsAccTypeSelection,
+  setAccSelectionComplete,
+}) {
+  const router = useRouter();
+
+  return (
+    <Flex
+      m={0}
+      maxW={"100%"}
+      width={"100%"}
+      height={"100%"}
+      flexDir={"row"}
+      alignItems={"center"}
+      minWidth={"100vw"}
+      minHeight={"100vh"}
+    >
+      <VStack
+        m={0}
+        p={0}
+        width={"50%"}
+        minH={"100vh"}
+        height={"100%"}
+        color={"black"}
+        justifyContent={"center "}
+        backgroundSize={"cover"}
+        backgroundPosition={"100% "}
+        cursor="pointer"
+        onClick={() => {
+          setBtnActive(1);
+          selectUserAccType("Expert");
+        }}
+        backgroundImage={
+          btnActive == 1 || btnActive == 0
+            ? `url("https://s3-alpha-sig.figma.com/img/1af8/2b0b/2aab5291c6d7d1dffbaa27b09b309dd3?Expires=1649030400&Signature=AawS5sdj8cjxNfSc2SSy0RUw04REC3cmTufXrRrvnJNBnG8wQoCCYrbSOmH0Fq3Uj16Wpr3yjE0NUM3RxU9~-6f-q1Fw6Qxym5VPp6W5yDpzeyyW2XfZerLyEh--tyailJDm-4B6hmn69x3CThgN93Idbm7Osg5SN8GWgC0Ubgn77ewoc5v671oXPXfpSfSNR5mw1CrCo18ubpk2YsxqmL7QQPmwHICoYnjudLLJ0rLfFq9fVp0aR~4dETYPjHeNTuI~ZSpTp00XBOM-SEsvIX9cicadmscluaMGNKkZ7wiJOutAY17Hn-jTVhKyTUuYn0cPVpoa7xRsPjbINFk6SA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA")`
+            : null
+        }
+        backgroundColor={"#0A1313"}
+      >
+        <Text
+          pos={"relative"}
+          top={"100px"}
+          fontSize={"72px"}
+          padding={"2px"}
+          px={0}
+          fontWeight={"400"}
+          lineHeight={"88px"}
+          letterSpacing={"0.04em"}
+          fontFamily={"Scope Light"}
+          color={btnActive == 1 || btnActive == 0 ? "#0A1313" : "#C7F83C"}
+          backgroundColor={
+            btnActive == 1 || btnActive == 0 ? "#C7F83C" : "#0A1313"
+          }
+        >
+          expert
+        </Text>
+        <Text
+          pos={"relative"}
+          top={"108px"}
+          color={"#F9FFF2"}
+          fontFamily={"PP Telegraf Light"}
+          fontSize={"16px"}
+          lineHeight={"24px"}
+        >
+          I want to provide my knowledge and expertise{" "}
+        </Text>
+        <Button
+          disabled={!isAccTypeSelected}
+          alignSelf="center"
+          backgroundColor={"#C7F83C"}
+          w="220px"
+          h={"40px"}
+          color={"#0A1313"}
+          pos={"relative"}
+          top={"200px"}
+          borderRadius={"32px"}
+          padding={"16px, 24px, 13px, 24px"}
+          onClick={(evt) => {
+            setIsAccTypeSelection(false);
+            router.push("/steps");
+            setAccSelectionComplete(true);
+          }}
+          visibility={btnActive == 1 ? "unset" : "hidden"}
+        >
+          Continue
+        </Button>
+      </VStack>
+      <VStack
+        m={0}
+        p={0}
+        width={"50%"}
+        minH={"100vh"}
+        height={"100%"}
+        justifyContent={"center "}
+        backgroundSize={"cover"}
+        backgroundPosition={"100% "}
+        cursor="pointer"
+        onClick={() => {
+          setBtnActive(2);
+          selectUserAccType("Builder");
+        }}
+        backgroundImage={
+          btnActive == 2
+            ? `url("https://s3-alpha-sig.figma.com/img/1af8/2b0b/2aab5291c6d7d1dffbaa27b09b309dd3?Expires=1649030400&Signature=AawS5sdj8cjxNfSc2SSy0RUw04REC3cmTufXrRrvnJNBnG8wQoCCYrbSOmH0Fq3Uj16Wpr3yjE0NUM3RxU9~-6f-q1Fw6Qxym5VPp6W5yDpzeyyW2XfZerLyEh--tyailJDm-4B6hmn69x3CThgN93Idbm7Osg5SN8GWgC0Ubgn77ewoc5v671oXPXfpSfSNR5mw1CrCo18ubpk2YsxqmL7QQPmwHICoYnjudLLJ0rLfFq9fVp0aR~4dETYPjHeNTuI~ZSpTp00XBOM-SEsvIX9cicadmscluaMGNKkZ7wiJOutAY17Hn-jTVhKyTUuYn0cPVpoa7xRsPjbINFk6SA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA")`
+            : null
+        }
+        backgroundColor={"#0A1313"}
+      >
+        <Text
+          pos={"relative"}
+          top={"100px"}
+          fontFamily={"Scope Light"}
+          padding={"2px"}
+          px={0}
+          fontWeight={"400"}
+          fontSize={"72px"}
+          lineHeight={"88px"}
+          letterSpacing={"0.04em"}
+          color={btnActive == 2 ? "#0A1313" : "#C7F83C"}
+          backgroundColor={btnActive == 2 ? "#C7F83C" : "#0A1313"}
+        >
+          builder
+        </Text>
+        <Text
+          pos={"relative"}
+          top={"108px"}
+          color={"#F9FFF2"}
+          fontFamily={"PP Telegraf Light"}
+          fontSize={"16px"}
+          lineHeight={"24px"}
+        >
+          I want to build a project
+        </Text>
+
+        <Button
+          disabled={!isAccTypeSelected}
+          alignSelf="center"
+          backgroundColor={"#C7F83C"}
+          color={"#0A1313"}
+          w="220px"
+          h={"40px"}
+          pos={"relative"}
+          top={"200px"}
+          borderRadius={"32px"}
+          padding={"16px, 24px, 13px, 24px"}
+          onClick={(evt) => {
+            setIsAccTypeSelection(false);
+            setAccSelectionComplete(true);
+          }}
+          visibility={btnActive == 2 ? "unset" : "hidden"}
+        >
+          Continue
+        </Button>
+      </VStack>
+    </Flex>
+  );
+}

--- a/components/SignUpSteps/merchantProfileStep.tsx
+++ b/components/SignUpSteps/merchantProfileStep.tsx
@@ -25,6 +25,7 @@ export const merchantProfileStep = ({ handleChange, values, errors }) => {
         overflow="hidden"
         cursor="pointer"
         backgroundColor={"#041A19E5"}
+        marginBottom={"180px"}
       >
         <Box p="4">
           <Box
@@ -53,16 +54,21 @@ export const merchantProfileStep = ({ handleChange, values, errors }) => {
                   href="https://www.sba.gov/business-guide/launch-your-business/choose-business-structure"
                   target={"_blank"}
                   rel="noopener noreferrer"
+                  _hover={{ textDecoration: "none" }}
                 >
-                  <Tooltip
-                    placement="auto-start"
-                    hasArrow
-                    label="Click to learn more "
+                  <Text
+                    marginBottom={1} //styleName: Body/body12;
+                    fontFamily={"PP Telegraf Light"}
+                    fontSize={"12px"}
+                    fontStyle={"normal"}
+                    fontWeight={"300"}
+                    lineHeight={"16px"}
+                    letterSpacing={"0em"}
+                    textAlign={"left"}
+                    color={"#0DD5D1"}
                   >
-                    <Box pos="relative">
-                      <FontAwesomeIcon icon={"info-circle"} />
-                    </Box>
-                  </Tooltip>
+                    click to learn more
+                  </Text>
                 </Link>
               </HStack>
               <Select
@@ -99,16 +105,30 @@ export const merchantProfileStep = ({ handleChange, values, errors }) => {
                   letterSpacing={"0.02em"}
                   textAlign={"left"}
                 >
-                  Business legal name
+                  Business name
                 </FormLabel>
                 <Tooltip
+                  backgroundColor={"#F9FFF2"}
+                  color={"#0A1313"}
                   placement="auto-start"
                   hasArrow
                   label="If you are a sole proprietor, partnership, or single-member LLC, your 'Business Name' may be registered as your personal name or your business’s DBA.
                   If you are an LLC, corporation, or non-profit, Twali requires that the 'Business Name' be in the company’s legal business name or DBA"
                 >
                   <Box pos="relative">
-                    <FontAwesomeIcon icon={"info-circle"} />
+                    <Text
+                      marginBottom={1} //styleName: Body/body12;
+                      fontFamily={"PP Telegraf Light"}
+                      fontSize={"12px"}
+                      fontStyle={"normal"}
+                      fontWeight={"300"}
+                      lineHeight={"16px"}
+                      letterSpacing={"0em"}
+                      textAlign={"left"}
+                      color={"#0DD5D1"}
+                    >
+                      What is my business type?
+                    </Text>
                   </Box>
                 </Tooltip>
               </HStack>
@@ -126,7 +146,7 @@ export const merchantProfileStep = ({ handleChange, values, errors }) => {
                 fontFamily={"PP Telegraf light"}
                 _placeholder={{ color: "#98B2B2" }}
                 value={values.businessName || ""}
-                placeholder="Business legal name"
+                placeholder="Business name"
                 name="businessName"
                 onChange={handleChange}
               />

--- a/components/SignUpSteps/merchantProfileStep.tsx
+++ b/components/SignUpSteps/merchantProfileStep.tsx
@@ -1,0 +1,173 @@
+import { useState } from "react";
+import { listOfCountries } from "../../utils/profileUtils";
+import {
+  FormControl,
+  Input,
+  Box,
+  FormLabel,
+  Select,
+  HStack,
+  Text,
+  Tooltip,
+  Link,
+} from "@chakra-ui/react";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+
+export const merchantProfileStep = ({ handleChange, values, errors }) => {
+  return (
+    <form style={{ alignSelf: "start" }}>
+      <Box
+        maxWidth={"496px"}
+        h="100%"
+        w="xl"
+        borderWidth="1px"
+        borderRadius="lg"
+        overflow="hidden"
+        cursor="pointer"
+        backgroundColor={"#041A19E5"}
+      >
+        <Box p="4">
+          <Box
+            mt="1"
+            fontWeight="semibold"
+            as="h4"
+            lineHeight="tight"
+            isTruncated
+          >
+            <FormControl p={2} id="business-type" isRequired>
+              <HStack justifyContent="space-between">
+                <FormLabel
+                  marginBottom={1}
+                  pos={"relative"}
+                  fontFamily={"PP Telegraf"}
+                  fontSize={"16px"}
+                  fontStyle={"normal"}
+                  fontWeight={"400"}
+                  lineHeight={"24p"}
+                  letterSpacing={"0.02em"}
+                  textAlign={"left"}
+                >
+                  Business type
+                </FormLabel>
+                <Link
+                  href="https://www.sba.gov/business-guide/launch-your-business/choose-business-structure"
+                  target={"_blank"}
+                  rel="noopener noreferrer"
+                >
+                  <Tooltip
+                    placement="auto-start"
+                    hasArrow
+                    label="Click to learn more "
+                  >
+                    <Box pos="relative">
+                      <FontAwesomeIcon icon={"info-circle"} />
+                    </Box>
+                  </Tooltip>
+                </Link>
+              </HStack>
+              <Select
+                errorBorderColor="red.300"
+                fontFamily={"PP Telegraf Light"}
+                placeholder="Select business type"
+                iconColor={"#F9FFF2"}
+                name="businessType"
+                onChange={handleChange}
+                color={values.businessType ? "#F9FFF2" : "#98B2B2"}
+              >
+                <option>I'm not incorporated!</option>
+                <option>Sole proprietorship</option>
+                <option>Partnership</option>
+                <option>Corporation</option>
+                <option>Single-member LLC</option>
+                <option>LLC</option>
+                <option>Non-profit</option>
+              </Select>
+              {/* {errors.businessType && (
+                        <Text fontSize='xs' fontWeight='400' color='red.500'>{errors.businessType}</Text>
+                      )} */}
+            </FormControl>
+            <FormControl p={2} id="business-name" isRequired>
+              <HStack display="flex" justifyContent="space-between">
+                <FormLabel
+                  marginBottom={1}
+                  pos={"relative"}
+                  fontFamily={"PP Telegraf"}
+                  fontSize={"16px"}
+                  fontStyle={"normal"}
+                  fontWeight={"400"}
+                  lineHeight={"24p"}
+                  letterSpacing={"0.02em"}
+                  textAlign={"left"}
+                >
+                  Business legal name
+                </FormLabel>
+                <Tooltip
+                  placement="auto-start"
+                  hasArrow
+                  label="If you are a sole proprietor, partnership, or single-member LLC, your 'Business Name' may be registered as your personal name or your business’s DBA.
+                  If you are an LLC, corporation, or non-profit, Twali requires that the 'Business Name' be in the company’s legal business name or DBA"
+                >
+                  <Box pos="relative">
+                    <FontAwesomeIcon icon={"info-circle"} />
+                  </Box>
+                </Tooltip>
+              </HStack>
+              <Input
+                disabled={values.businessType === "I'm not incorporated!"}
+                px={4}
+                fontSize="16px"
+                borderColor={"#587070"}
+                height={"40px"}
+                borderRadius={"4px"}
+                marginBottom={"12px"}
+                required
+                isInvalid={errors.businessName}
+                errorBorderColor="red.300"
+                fontFamily={"PP Telegraf light"}
+                _placeholder={{ color: "#98B2B2" }}
+                value={values.businessName || ""}
+                placeholder="Business legal name"
+                name="businessName"
+                onChange={handleChange}
+              />
+              {errors.businessName && (
+                <Text fontSize="xs" fontWeight="400" color="red.500">
+                  {errors.businessName}
+                </Text>
+              )}
+            </FormControl>
+
+            <FormControl p={2} id="business-location" isRequired>
+              <FormLabel
+                marginBottom={1}
+                pos={"relative"}
+                fontFamily={"PP Telegraf"}
+                fontSize={"16px"}
+                fontStyle={"normal"}
+                fontWeight={"400"}
+                lineHeight={"24p"}
+                letterSpacing={"0.02em"}
+                textAlign={"left"}
+              >
+                Business location
+              </FormLabel>
+              <Select
+                fontFamily={"PP Telegraf Light"}
+                color={values.businessLocation ? "#F9FFF2" : "#98B2B2"}
+                placeholder="Select business location"
+                name="businessLocation"
+                onChange={handleChange}
+                disabled={values.businessType === "I'm not incorporated!"}
+              >
+                {listOfCountries()}
+              </Select>
+              {/* {errors.businessLocation && (
+                        <Text fontSize='xs' fontWeight='400' color='red.500'>{errors.businessType}</Text>
+                      )} */}
+            </FormControl>
+          </Box>
+        </Box>
+      </Box>
+    </form>
+  );
+};

--- a/components/SignUpSteps/professionalProfileStep.tsx
+++ b/components/SignUpSteps/professionalProfileStep.tsx
@@ -1,0 +1,118 @@
+import { MultiSelect } from "../Profile/Components/MultiSelect";
+import { listOfCountries } from "../../utils/profileUtils";
+import {
+  FormControl,
+  Input,
+  Box,
+  FormLabel,
+  Select,
+  Text,
+} from "@chakra-ui/react";
+import { functionalExpertiseList } from "../../utils/functionalExpertiseConstants";
+import { industryExpertiseList } from "../../utils/industryExpertiseConstants";
+
+export const professionalProfileStep = ({ handleChange, values, errors }) => {
+  return (
+    <form style={{ alignSelf: "start" }}>
+      <Box
+        maxWidth={"496px"}
+        h="100%"
+        w="xl"
+        borderWidth="1px"
+        borderRadius="lg"
+        overflow="hidden"
+        cursor="pointer"
+        backgroundColor={"#041A19E5"}
+      >
+        <Box p="4">
+          <Box
+            mt="1"
+            fontWeight="semibold"
+            as="h4"
+            lineHeight="tight"
+            isTruncated
+          >
+            <FormControl p={2} id="current-company-title" isRequired>
+              <FormLabel
+                marginBottom={1}
+                pos={"relative"}
+                fontFamily={"PP Telegraf"}
+                fontSize={"16px"}
+                fontStyle={"normal"}
+                fontWeight={"400"}
+                lineHeight={"24p"}
+                letterSpacing={"0.02em"}
+                textAlign={"left"}
+              >
+                Current title
+              </FormLabel>
+              <Input
+                px={2}
+                fontSize="16px"
+                borderColor={"#587070"}
+                height={"40px"}
+                borderRadius={"4px"}
+                marginBottom={"12px"}
+                isInvalid={errors.currTitle}
+                errorBorderColor="red.300"
+                fontFamily={"PP Telegraf light"}
+                _placeholder={{ color: "#98B2B2" }}
+                value={values.currTitle || ""}
+                required
+                placeholder="Current title"
+                name="currTitle"
+                onChange={handleChange}
+              />
+              {errors.currTitle && (
+                <Text fontSize="xs" fontWeight="400" color="red.500">
+                  {errors.currTitle}
+                </Text>
+              )}
+            </FormControl>
+            <FormControl p={2} id="current-location">
+              <FormLabel
+                marginBottom={1}
+                pos={"relative"}
+                fontFamily={"PP Telegraf"}
+                fontSize={"16px"}
+                fontStyle={"normal"}
+                fontWeight={"400"}
+                lineHeight={"24p"}
+                letterSpacing={"0.02em"}
+                textAlign={"left"}
+              >
+                Current location
+              </FormLabel>
+              <Select
+                color="#F9FFF2"
+                fontFamily={"PP Telegraf Light"}
+                placeholder="Select current location"
+                _placeholder={{ color: "#98B2B2 !important" }}
+                name="currLocation"
+                onChange={handleChange}
+              >
+                {listOfCountries()}
+              </Select>
+            </FormControl>
+            <MultiSelect
+              name={"functionalExpertise"}
+              formLabel={"Functional expertise"}
+              handleChange={handleChange}
+              defaultValues={[]}
+              options={functionalExpertiseList}
+              maxSelections={3}
+            />
+            <MultiSelect
+              name={"industryExpertise"}
+              formLabel={"Industry expertise"}
+              handleChange={handleChange}
+              defaultValues={[]}
+              options={industryExpertiseList}
+              maxSelections={3}
+            />
+          </Box>
+        </Box>
+      </Box>
+    </form>
+  );
+};

--- a/components/SignUpSteps/professionalProfileStep.tsx
+++ b/components/SignUpSteps/professionalProfileStep.tsx
@@ -84,10 +84,10 @@ export const professionalProfileStep = ({ handleChange, values, errors }) => {
                 Current location
               </FormLabel>
               <Select
-                color="#F9FFF2"
                 fontFamily={"PP Telegraf Light"}
                 placeholder="Select current location"
                 _placeholder={{ color: "#98B2B2 !important" }}
+                color={values.currLocation ? "#F9FFF2" : "#98B2B2"}
                 name="currLocation"
                 onChange={handleChange}
               >

--- a/components/SignUpSteps/userProfileStep.tsx
+++ b/components/SignUpSteps/userProfileStep.tsx
@@ -175,10 +175,10 @@ export const userProfileStep = ({ handleChange, values, errors }) => {
                   lineHeight={"16px"}
                   letterSpacing={"0em"}
                   textAlign={"left"}
-                  color={"#0DD5D1"}
+                  color={"#98B2B2"}
                   requiredIndicator={null}
                 >
-                  your email won’t be shared with others
+                  your email won&apos;t be shared with others
                 </FormLabel>
               </HStack>
               <Input
@@ -263,29 +263,42 @@ export const userProfileStep = ({ handleChange, values, errors }) => {
               </FormControl>
             </HStack>
             <FormControl pt={2} pb={3} px={2} id="website">
-              <Box display="flex" justifyContent="space-between">
-                <FormLabel
-                  marginBottom={1}
-                  pos={"relative"}
-                  fontFamily={"PP Telegraf"}
-                  fontSize={"16px"}
-                  fontStyle={"normal"}
-                  fontWeight={"400"}
-                  lineHeight={"24p"}
-                  letterSpacing={"0.02em"}
-                  textAlign={"left"}
+              <Box display="flex" justifyContent="space-between" width={"100%"}>
+                <HStack
+                  alignItems={"baseline"}
+                  justifyContent={"space-between"}
+                  marginBottom={0}
+                  width={"100%"}
                 >
-                  Your Website URL
-                </FormLabel>
-                <Tooltip
-                  placement="auto-start"
-                  hasArrow
-                  label="Add a personal or business website here"
-                >
-                  <Box pos="relative">
-                    <FontAwesomeIcon icon={"info-circle"} />
-                  </Box>
-                </Tooltip>
+                  <FormLabel
+                    marginBottom={1}
+                    pos={"relative"}
+                    fontFamily={"PP Telegraf"}
+                    fontSize={"16px"}
+                    fontStyle={"normal"}
+                    fontWeight={"400"}
+                    lineHeight={"24p"}
+                    letterSpacing={"0.02em"}
+                    textAlign={"left"}
+                  >
+                    Website URL
+                  </FormLabel>
+
+                  <FormLabel
+                    marginBottom={1} //styleName: Body/body12;
+                    fontFamily={"PP Telegraf Light"}
+                    fontSize={"12px"}
+                    fontStyle={"normal"}
+                    fontWeight={"300"}
+                    lineHeight={"16px"}
+                    letterSpacing={"0em"}
+                    textAlign={"left"}
+                    color={"#98B2B2"}
+                    requiredIndicator={null}
+                  >
+                    Add a personal or business website here
+                  </FormLabel>
+                </HStack>
               </Box>
               <Input
                 px={2}

--- a/components/SignUpSteps/userProfileStep.tsx
+++ b/components/SignUpSteps/userProfileStep.tsx
@@ -1,0 +1,308 @@
+import {
+  FormControl,
+  Input,
+  Box,
+  FormLabel,
+  HStack,
+  Text,
+  Tooltip,
+} from "@chakra-ui/react";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+
+export const userProfileStep = ({ handleChange, values, errors }) => {
+  return (
+    <form style={{ alignSelf: "start" }}>
+      <Box
+        maxWidth={"496px"}
+        mx={0}
+        my={2}
+        h={"532px"}
+        border="1px solid #587070"
+        borderRadius="16px"
+        overflow="hidden"
+        cursor="pointer"
+        backgroundColor={"#041A19E5"}
+        fontFamily={"PP Telegraf"}
+        boxShadow={"8px 16px 24px 0px #062B2A8F"}
+      >
+        <Box p="4">
+          <Box
+            mt="1"
+            fontWeight="semibold"
+            as="h4"
+            lineHeight="tight"
+            isTruncated
+          >
+            <HStack spacing={2}>
+              <FormControl p={2} mx={1} id="first-name" isRequired>
+                <FormLabel
+                  marginBottom={1}
+                  pos={"relative"}
+                  fontFamily={"PP Telegraf"}
+                  fontSize={"16px"}
+                  fontStyle={"normal"}
+                  fontWeight={"400"}
+                  lineHeight={"24p"}
+                  letterSpacing={"0.02em"}
+                  textAlign={"left"}
+                >
+                  First name
+                </FormLabel>
+                <Input
+                  px={2}
+                  fontSize="16px"
+                  borderColor={"#587070"}
+                  height={"40px"}
+                  borderRadius={"4px"}
+                  marginBottom={"12px"}
+                  required
+                  isInvalid={errors.firstName}
+                  errorBorderColor="red.300"
+                  placeholder="First name"
+                  name="firstName"
+                  fontFamily={"PP Telegraf light"}
+                  _placeholder={{ color: "#98B2B2" }}
+                  value={values.firstName || ""}
+                  onChange={handleChange}
+                />
+                {errors.firstName && (
+                  <Text fontSize="xs" fontWeight="400" color="red.500">
+                    {errors.firstName}
+                  </Text>
+                )}
+              </FormControl>
+              <FormControl p={2} mx={1} id="last-name" isRequired>
+                <FormLabel
+                  marginBottom={1}
+                  pos={"relative"}
+                  fontFamily={"PP Telegraf"}
+                  fontSize={"16px"}
+                  fontStyle={"normal"}
+                  fontWeight={"400"}
+                  lineHeight={"24p"}
+                  letterSpacing={"0.02em"}
+                  textAlign={"left"}
+                >
+                  Last name
+                </FormLabel>
+                <Input
+                  px={2}
+                  fontSize="16px"
+                  borderColor={"#587070"}
+                  height={"40px"}
+                  borderRadius={"4px"}
+                  marginBottom={"12px"}
+                  required
+                  isInvalid={errors.lastName}
+                  errorBorderColor="red.300"
+                  placeholder="Last name"
+                  name="lastName"
+                  fontFamily={"PP Telegraf light"}
+                  _placeholder={{ color: "#98B2B2" }}
+                  value={values.lastName || ""}
+                  onChange={handleChange}
+                />
+                {errors.lastName && (
+                  <Text fontSize="xs" fontWeight="400" color="red.500">
+                    {errors.lastName}
+                  </Text>
+                )}
+              </FormControl>
+            </HStack>
+            <FormControl p={2} mx={1} id="display-name" isRequired>
+              <FormLabel
+                marginBottom={1}
+                pos={"relative"}
+                fontFamily={"PP Telegraf"}
+                fontSize={"16px"}
+                fontStyle={"normal"}
+                fontWeight={"400"}
+                lineHeight={"24p"}
+                letterSpacing={"0.02em"}
+                textAlign={"left"}
+              >
+                Display name
+              </FormLabel>
+              <Input
+                px={2}
+                fontSize="16px"
+                borderColor={"#587070"}
+                height={"40px"}
+                borderRadius={"4px"}
+                marginBottom={"12px"}
+                required
+                isInvalid={errors.userName}
+                errorBorderColor="red.300"
+                placeholder="choose your unique name"
+                name="userName"
+                fontFamily={"PP Telegraf light"}
+                _placeholder={{ color: "#98B2B2" }}
+                value={values.userName || ""}
+                onChange={handleChange}
+              />
+              {errors.userName && (
+                <Text fontSize="xs" fontWeight="400" color="red.500">
+                  {errors.userName}
+                </Text>
+              )}
+            </FormControl>
+            <FormControl p={2} mx={1} id="email" isRequired>
+              <HStack
+                alignItems={"baseline"}
+                justifyContent={"space-between"}
+                marginBottom={0}
+              >
+                <FormLabel
+                  marginBottom={1}
+                  pos={"relative"}
+                  fontFamily={"PP Telegraf"}
+                  fontSize={"16px"}
+                  fontStyle={"normal"}
+                  fontWeight={"400"}
+                  lineHeight={"24p"}
+                  letterSpacing={"0.02em"}
+                  textAlign={"left"}
+                >
+                  Email
+                </FormLabel>
+
+                <FormLabel
+                  marginBottom={1} //styleName: Body/body12;
+                  fontFamily={"PP Telegraf Light"}
+                  fontSize={"12px"}
+                  fontStyle={"normal"}
+                  fontWeight={"300"}
+                  lineHeight={"16px"}
+                  letterSpacing={"0em"}
+                  textAlign={"left"}
+                  color={"#0DD5D1"}
+                  requiredIndicator={null}
+                >
+                  your email won’t be shared with others
+                </FormLabel>
+              </HStack>
+              <Input
+                px={2}
+                fontSize="16px"
+                borderColor={"#587070"}
+                height={"40px"}
+                borderRadius={"4px"}
+                marginBottom={"12px"}
+                required
+                isInvalid={errors.email}
+                errorBorderColor="red.300"
+                placeholder="Email"
+                name="email"
+                fontFamily={"PP Telegraf light"}
+                _placeholder={{ color: "#98B2B2" }}
+                value={values.email || ""}
+                onChange={handleChange}
+              />
+              {errors.email && (
+                <Text fontSize="xs" fontWeight="400" color="red.500">
+                  {errors.email}
+                </Text>
+              )}
+            </FormControl>
+            <HStack spacing={2}>
+              <FormControl p={2} mx={1} id="twitter">
+                <FormLabel
+                  marginBottom={1}
+                  pos={"relative"}
+                  fontFamily={"PP Telegraf"}
+                  fontSize={"16px"}
+                  fontStyle={"normal"}
+                  fontWeight={"400"}
+                  lineHeight={"24p"}
+                  letterSpacing={"0.02em"}
+                  textAlign={"left"}
+                >
+                  Twitter URL
+                </FormLabel>
+                <Input
+                  px={2}
+                  fontSize="16px"
+                  borderColor={"#587070"}
+                  height={"40px"}
+                  borderRadius={"4px"}
+                  marginBottom={"12px"}
+                  placeholder="Twitter"
+                  _placeholder={{ color: "#98B2B2" }}
+                  fontFamily={"PP Telegraf Light"}
+                  name="twitter"
+                  onChange={handleChange}
+                />
+              </FormControl>
+              <FormControl p={2} mx={1} id="linkedin">
+                <FormLabel
+                  marginBottom={1}
+                  pos={"relative"}
+                  fontFamily={"PP Telegraf"}
+                  fontSize={"16px"}
+                  fontStyle={"normal"}
+                  fontWeight={"400"}
+                  lineHeight={"24p"}
+                  letterSpacing={"0.02em"}
+                  textAlign={"left"}
+                >
+                  LinkedIn URL
+                </FormLabel>
+                <Input
+                  px={2}
+                  fontSize="16px"
+                  borderColor={"#587070"}
+                  height={"40px"}
+                  borderRadius={"4px"}
+                  marginBottom={"12px"}
+                  placeholder="LinkedIn"
+                  _placeholder={{ color: "#98B2B2" }}
+                  fontFamily={"PP Telegraf Light"}
+                  name="linkedIn"
+                  onChange={handleChange}
+                />
+              </FormControl>
+            </HStack>
+            <FormControl pt={2} pb={3} px={2} id="website">
+              <Box display="flex" justifyContent="space-between">
+                <FormLabel
+                  marginBottom={1}
+                  pos={"relative"}
+                  fontFamily={"PP Telegraf"}
+                  fontSize={"16px"}
+                  fontStyle={"normal"}
+                  fontWeight={"400"}
+                  lineHeight={"24p"}
+                  letterSpacing={"0.02em"}
+                  textAlign={"left"}
+                >
+                  Your Website URL
+                </FormLabel>
+                <Tooltip
+                  placement="auto-start"
+                  hasArrow
+                  label="Add a personal or business website here"
+                >
+                  <Box pos="relative">
+                    <FontAwesomeIcon icon={"info-circle"} />
+                  </Box>
+                </Tooltip>
+              </Box>
+              <Input
+                px={2}
+                fontSize="16px"
+                borderColor={"#587070"}
+                height={"40px"}
+                borderRadius={"4px"}
+                placeholder="Website URL"
+                _placeholder={{ color: "#98B2B2" }}
+                fontFamily={"PP Telegraf Light"}
+                name="website"
+                onChange={handleChange}
+              />
+            </FormControl>
+          </Box>
+        </Box>
+      </Box>
+    </form>
+  );
+};

--- a/components/SignUpSteps/userProfileStep.tsx
+++ b/components/SignUpSteps/userProfileStep.tsx
@@ -5,9 +5,7 @@ import {
   FormLabel,
   HStack,
   Text,
-  Tooltip,
 } from "@chakra-ui/react";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
 export const userProfileStep = ({ handleChange, values, errors }) => {
   return (

--- a/data/dynamodb.js
+++ b/data/dynamodb.js
@@ -10,12 +10,12 @@ const getDynamoDBClient = () => {
 
   // Only needed with local development.
   // if (process.env.LOCAL_DYNAMO_DB_ENDPOINT) {
-  //   AWS.config.update({
+ AWS.config.update({
   //     accessKeyId: "xxxx",
   //     secretAccessKey: "xxxx",
-  //     region: "us-east-1",
+     region: "us-east-1",
   //     endpoint: "http://localhost:8000",
-  //   });
+  });
   // }
 
   const options = {

--- a/data/dynamodb.js
+++ b/data/dynamodb.js
@@ -9,14 +9,14 @@ const getDynamoDBClient = () => {
     : "us-east-2";
 
   // Only needed with local development.
-  if (process.env.LOCAL_DYNAMO_DB_ENDPOINT) {
-    AWS.config.update({
-      accessKeyId: "xxxx",
-      secretAccessKey: "xxxx",
-      region: "us-east-1",
-      endpoint: "http://localhost:8000",
-    });
-  }
+  // if (process.env.LOCAL_DYNAMO_DB_ENDPOINT) {
+  //   AWS.config.update({
+  //     accessKeyId: "xxxx",
+  //     secretAccessKey: "xxxx",
+  //     region: "us-east-1",
+  //     endpoint: "http://localhost:8000",
+  //   });
+  // }
 
   const options = {
     convertEmptyValues: true,

--- a/data/dynamodb.js
+++ b/data/dynamodb.js
@@ -9,15 +9,15 @@ const getDynamoDBClient = () => {
     : "us-east-2";
 
   // Only needed with local development.
-  // if (process.env.LOCAL_DYNAMO_DB_ENDPOINT) {
-    // AWS.config.update({
-    //   accessKeyId: 'xxxx',
-    //   secretAccessKey: 'xxxx',
-    //   region: "us-east-1",
-    //   endpoint: "http://localhost:8000",
-    // });
-    // };
-  
+  if (process.env.LOCAL_DYNAMO_DB_ENDPOINT) {
+    AWS.config.update({
+      accessKeyId: "xxxx",
+      secretAccessKey: "xxxx",
+      region: "us-east-1",
+      endpoint: "http://localhost:8000",
+    });
+  }
+
   const options = {
     convertEmptyValues: true,
     region: dynamoDBRegion,
@@ -105,7 +105,7 @@ module.exports = {
           currLocation: currLocation ? currLocation : null,
           functionalExpertise: functionalExpertise,
           industryExpertise: industryExpertise,
-          companyInfo: companyInfo ? companyInfo: null,
+          companyInfo: companyInfo ? companyInfo : null,
         },
         // ConditionExpression: attribute_not_exists(userWallet)
       })
@@ -133,7 +133,7 @@ module.exports = {
       .promise()
       .then((data) => data.Items[0])
       .catch(console.error);
-      return dbUser;
+    return dbUser;
   },
 
   /**
@@ -157,7 +157,7 @@ module.exports = {
       .promise()
       .then((data) => data.Items[0])
       .catch(console.error);
-      return dbUser;
+    return dbUser;
   },
 
   /**
@@ -167,59 +167,61 @@ module.exports = {
    * @example See docs about editing existing attributes -> https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB/DocumentClient.html#update-property
    */
   updateUserExpertise: async (userWallet, attributes) => {
-    console.log('UPDATE USER EXP DYNAMO');
+    console.log("UPDATE USER EXP DYNAMO");
     console.log(userWallet);
     console.log(attributes);
-    let {
-      userName,
-      functionalExpertise,
-      industryExpertise,
-    } = attributes;
+    let { userName, functionalExpertise, industryExpertise } = attributes;
     console.log(attributes);
-  await getDynamoDBClient().update({
-      TableName,
-      Key: {
-        userWallet: userWallet,
-        userName: userName,
-      },
-      UpdateExpression: "SET functionalExpertise = :functionalExpertise, industryExpertise = :industryExpertise",
-      // ConditionExpression: "",
-      ExpressionAttributeValues: {
-        ":functionalExpertise": functionalExpertise,
-        ":industryExpertise": industryExpertise,
-      },
-    }).promise()
-    .then(data => console.log(data)).catch(console.error);
-  }, 
-    /**
-   * @desc Edits an existing users item's attributes, or adds a new item to the table if it does not already exist.
-   * @param {object} - function takes an object as a the parameter with primary and attributes. Object will need to the primary key and any attributes that are being updated or created.
-   * @dev New items can be added to a user and does need to be predefined in the table. Any values in 'UpdateExpression' need to be defined will values within 'ExpressionAttributeValues'.
-   * @example See docs about editing existing attributes -> https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB/DocumentClient.html#update-property
-   */
-     updateUserProfile: async (userWallet, attributes) => {
-      console.log('UPDATE USER PROF DYNAMO');
-      console.log(userWallet);
-      console.log(attributes);
-      let {
-        userName,
-        firstName,
-        lastName,
-        currTitle,
-        currLocation,
-        bio,
-        linkedIn,
-        twitter,
-        email
-      } = attributes;
-  
-    await getDynamoDBClient().update({
+    await getDynamoDBClient()
+      .update({
         TableName,
         Key: {
           userWallet: userWallet,
           userName: userName,
         },
-        UpdateExpression: "SET firstName = :firstName, lastName = :lastName, currTitle = :currTitle, currLocation = :currLocation, bio = :bio, linkedIn = :linkedIn, twitter = :twitter, email = :email",
+        UpdateExpression:
+          "SET functionalExpertise = :functionalExpertise, industryExpertise = :industryExpertise",
+        // ConditionExpression: "",
+        ExpressionAttributeValues: {
+          ":functionalExpertise": functionalExpertise,
+          ":industryExpertise": industryExpertise,
+        },
+      })
+      .promise()
+      .then((data) => console.log(data))
+      .catch(console.error);
+  },
+  /**
+   * @desc Edits an existing users item's attributes, or adds a new item to the table if it does not already exist.
+   * @param {object} - function takes an object as a the parameter with primary and attributes. Object will need to the primary key and any attributes that are being updated or created.
+   * @dev New items can be added to a user and does need to be predefined in the table. Any values in 'UpdateExpression' need to be defined will values within 'ExpressionAttributeValues'.
+   * @example See docs about editing existing attributes -> https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB/DocumentClient.html#update-property
+   */
+  updateUserProfile: async (userWallet, attributes) => {
+    console.log("UPDATE USER PROF DYNAMO");
+    console.log(userWallet);
+    console.log(attributes);
+    let {
+      userName,
+      firstName,
+      lastName,
+      currTitle,
+      currLocation,
+      bio,
+      linkedIn,
+      twitter,
+      email,
+    } = attributes;
+
+    await getDynamoDBClient()
+      .update({
+        TableName,
+        Key: {
+          userWallet: userWallet,
+          userName: userName,
+        },
+        UpdateExpression:
+          "SET firstName = :firstName, lastName = :lastName, currTitle = :currTitle, currLocation = :currLocation, bio = :bio, linkedIn = :linkedIn, twitter = :twitter, email = :email",
         // ConditionExpression: "",
         ExpressionAttributeValues: {
           ":firstName": firstName,
@@ -231,46 +233,46 @@ module.exports = {
           ":twitter": twitter,
           ":email": email,
         },
-      }).promise()
-      .then(data => console.log(data)).catch(console.error);
-    }, 
+      })
+      .promise()
+      .then((data) => console.log(data))
+      .catch(console.error);
+  },
   /**
    * @desc Edits an existing users item's attributes, or adds a new item to the table if it does not already exist.
    * @param {object} - function takes an object as a the parameter with primary and attributes. Object will need to the primary key and any attributes that are being updated or created.
    * @dev New items can be added to a user and does need to be predefined in the table. Any values in 'UpdateExpression' need to be defined will values within 'ExpressionAttributeValues'.
    * @example See docs about editing existing attributes -> https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB/DocumentClient.html#update-property
    */
-    updateUserCompanyData: async (userWallet, attributes) => {
-      console.log('UPDATE USER COMPANY DATA DYNAMO');
+  updateUserCompanyData: async (userWallet, attributes) => {
+    console.log("UPDATE USER COMPANY DATA DYNAMO");
 
-      let {
-        companyData,
-        userName,
-      } = attributes;
-  
-      let companyInfo = companyData; // to use companyInfo as the new array obj in the front-end
+    let { companyData, userName } = attributes;
 
-      console.log('COMPANY INFO', companyInfo);
-      const getParams = (updatedCompanyData) => {
-        const params = {
-          TableName,
-          Key: {
-            userWallet: userWallet,
-            userName: userName,
-          },
-          UpdateExpression: 'SET companyInfo = :updatedData',
-           ExpressionAttributeValues: {
-                ":updatedData": updatedCompanyData,
-            },
-            ReturnValues:"UPDATED_NEW"
-        };
-        return params;
-        }
+    let companyInfo = companyData; // to use companyInfo as the new array obj in the front-end
+
+    console.log("COMPANY INFO", companyInfo);
+    const getParams = (updatedCompanyData) => {
+      const params = {
+        TableName,
+        Key: {
+          userWallet: userWallet,
+          userName: userName,
+        },
+        UpdateExpression: "SET companyInfo = :updatedData",
+        ExpressionAttributeValues: {
+          ":updatedData": updatedCompanyData,
+        },
+        ReturnValues: "UPDATED_NEW",
+      };
+      return params;
+    };
 
     // Updating the companyInfo array
     let params = getParams(companyInfo);
-  
-    await getDynamoDBClient().update({
+
+    await getDynamoDBClient()
+      .update({
         TableName: params.TableName,
         Key: {
           userWallet: userWallet,
@@ -278,9 +280,11 @@ module.exports = {
         },
         UpdateExpression: params.UpdateExpression,
         ExpressionAttributeValues: params.ExpressionAttributeValues,
-        ReturnValues:"ALL_NEW"
-      }).promise().catch(console.error);
-    }, 
+        ReturnValues: "ALL_NEW",
+      })
+      .promise()
+      .catch(console.error);
+  },
   /**
    * @desc Directly access a list of users in the table by scanning the table with `TableName`
    * @dev This can be altered to included any additional attributes with 'ProjectionExpression'.
@@ -293,8 +297,8 @@ module.exports = {
         TableName,
       })
       .promise()
-      .then(data => data.Items)
-      .catch(console.error); 
-      return allUsers;
+      .then((data) => data.Items)
+      .catch(console.error);
+    return allUsers;
   },
 };

--- a/infrastructure/provisionTable.js
+++ b/infrastructure/provisionTable.js
@@ -5,7 +5,7 @@ require("dotenv").config();
 // Only used in local development
 AWS.config.update({
   region: "us-east-1",
-  endpoint: process.env.LOCAL_DYNAMO_DB_ENDPOINT,
+  // endpoint: process.env.LOCAL_DYNAMO_DB_ENDPOINT,
 });
 
 let dynamodb = new AWS.DynamoDB();

--- a/infrastructure/provisionTable.js
+++ b/infrastructure/provisionTable.js
@@ -5,7 +5,7 @@ require("dotenv").config();
 // Only used in local development
 AWS.config.update({
   region: "us-east-1",
-  // endpoint: process.env.LOCAL_DYNAMO_DB_ENDPOINT,
+  endpoint: process.env.LOCAL_DYNAMO_DB_ENDPOINT,
 });
 
 let dynamodb = new AWS.DynamoDB();

--- a/infrastructure/provisionTable.js
+++ b/infrastructure/provisionTable.js
@@ -3,10 +3,10 @@ var AWS = require("aws-sdk");
 require("dotenv").config();
 
 // Only used in local development
-AWS.config.update({
-  region: "us-east-1",
-  // endpoint: process.env.LOCAL_DYNAMO_DB_ENDPOINT,
-});
+// AWS.config.update({
+//   region: "us-east-1",
+//   // endpoint: process.env.LOCAL_DYNAMO_DB_ENDPOINT,
+// });
 
 let dynamodb = new AWS.DynamoDB();
 

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -2,11 +2,11 @@ import "../styles/global.css";
 import { AppProps } from "next/app";
 import * as React from "react";
 import { ChakraProvider, extendTheme, ThemeConfig } from "@chakra-ui/react";
-import { StepsStyleConfig as Steps } from "chakra-ui-steps";
 import { library } from "@fortawesome/fontawesome-svg-core";
 import { fab } from "@fortawesome/free-brands-svg-icons";
 import { fas } from "@fortawesome/free-solid-svg-icons";
 import { mode } from "@chakra-ui/theme-tools";
+import { customSteps } from "../styles/customStepsTheme";
 
 library.add(fab, fas);
 
@@ -17,7 +17,16 @@ const config: ThemeConfig = {
 
 const theme = extendTheme({
   config,
+
   styles: {
+    color: {
+      textPrimary: "#F9FFF2",
+      textSubtle: "#98B2B2",
+      textBold: "#C7F83C",
+    },
+    backgroundColor: {
+      actionBold: "#C7F83C",
+    },
     global: (props) => ({
       body: {
         bg: mode("white", "rgb(30, 30, 30)")(props),
@@ -25,8 +34,9 @@ const theme = extendTheme({
       },
     }),
   },
+
   components: {
-    Steps,
+    Steps: customSteps,
   },
 });
 

--- a/pages/steps.tsx
+++ b/pages/steps.tsx
@@ -1,29 +1,11 @@
 import HeaderNav from "../components/HeaderNav/HeaderNav";
 import { Container, Flex, VStack } from "@chakra-ui/react";
 import SignUpSteps from "../components/SignUpSteps/SignUpSteps";
-import background from "../public/twali-assets/backgroundscreen.png";
 
 const Steps = () => {
   return (
     <>
-      <Container
-        width="100%"
-        minHeight="100vh"
-        maxW={"100%"}
-        pos={"relative"}
-        bgSize={"cover"}
-        bgPosition={"center"}
-        bgImg={`url(${background.src})`}
-      >
-        <HeaderNav whichPage="steps" />
-        <Container maxW="container.xl" pb={6} px={0}>
-          <Flex h="full">
-            <VStack w="full" h="full" spacing={8} alignItems="flex-start">
-              <SignUpSteps />
-            </VStack>
-          </Flex>
-        </Container>
-      </Container>
+      <SignUpSteps />
     </>
   );
 };

--- a/pages/steps.tsx
+++ b/pages/steps.tsx
@@ -8,8 +8,7 @@ const Steps = () => {
     <>
       <Container
         width="100%"
-        height="1024px"
-        minH={"100vh"}
+        minHeight="100vh"
         maxW={"100%"}
         pos={"relative"}
         bgSize={"cover"}

--- a/styles/customStepsTheme.ts
+++ b/styles/customStepsTheme.ts
@@ -1,0 +1,66 @@
+import { background, extendTheme } from "@chakra-ui/react";
+import type { ComponentStyleConfig } from '@chakra-ui/theme'
+
+// You can also use the more specific type for
+// a multipart component: ComponentMultiStyleConfig
+export const customSteps: ComponentStyleConfig = {
+    // The parts of the component
+    parts: [
+      "connector",
+      "description",
+      "icon",
+      "label",
+      "labelContainer",
+      "step",
+      "stepContainer",
+      "stepIconContainer",
+      "steps",],
+    // The base styles for each part
+    baseStyle: {
+      steps: {
+       display: "flex",
+        fontFamily: "PP Telegraf",
+        fontSize:"16px",
+        lineHeight:"24px",
+        width: "600px" 
+      },
+      connector: {
+        borderTopWidth: "0"
+      },
+      stepContainer:{
+       color: "#98B2B2",
+       display: "flex"
+      },
+      stepIconContainer: {
+        display: "flex",
+        alignSelf:"center",
+        justifySelf:"center",
+        width: "24px",
+        height: "24px",
+        border: "1px solid white",
+        borderRadius: "50%",
+        span:{fontSize:"12px"}
+      },
+      label: {
+        paddingLeft: "7px",
+        color: "#F9FFF2",
+      },
+      icon: {
+        borderRadius: "50%",
+        height: "24px",
+        width: "24px",
+        border:"1px solid white",
+        backgroundColor: "transparent",  
+        color: "#F9FFF2",
+        fontSize:"12px"
+      },
+       
+      
+    },
+    // The size styles for each part
+    sizes: {},
+    // The variant styles for each part
+    variants: {},
+    // The default `size` or `variant` values
+    defaultProps: {},
+  }

--- a/styles/global.css
+++ b/styles/global.css
@@ -29,6 +29,17 @@ img {
 .body-animation > svg {
   min-width: 100% !important;
 }
+div[aria-current="step"] > span {
+  color: #c7f83c;
+}
+div[aria-current="step"]:first-of-type {
+  border: 1px solid #c7f83c;
+  border-radius: 50%;
+}
+.chakra-steps > div:first-of-type > div > div > span {
+  position: relative;
+  left: 1px;
+}
 
 @font-face {
   font-family: "GrandSlang Italic";

--- a/styles/global.css
+++ b/styles/global.css
@@ -41,6 +41,15 @@ div[aria-current="step"]:first-of-type {
   left: 1px;
 }
 
+span[role="presentation"] {
+  color: #f9fff2;
+}
+input:focus,
+select:focus {
+  border-color: #c7f83c !important;
+  box-shadow: none !important;
+}
+
 @font-face {
   font-family: "GrandSlang Italic";
   src: url("../public/fonts/GrandSlang-Italic.eot");

--- a/styles/global.css
+++ b/styles/global.css
@@ -29,6 +29,7 @@ img {
 .body-animation > svg {
   min-width: 100% !important;
 }
+
 @font-face {
   font-family: "GrandSlang Italic";
   src: url("../public/fonts/GrandSlang-Italic.eot");

--- a/styles/twaliTheme.ts
+++ b/styles/twaliTheme.ts
@@ -1,0 +1,12 @@
+import { background, extendTheme } from "@chakra-ui/react";
+
+export const twaliTheme = extendTheme({
+    color: {
+        textPrimary: "#F9FFF2",
+        textSubtle: "#98B2B2",
+        textBold: "#C7F83C",
+    },
+    backgroundColor: {
+    actionBold:"#C7F83C"
+    }
+})

--- a/test/steps.py
+++ b/test/steps.py
@@ -1,0 +1,165 @@
+from selenium.webdriver.chrome.options import Options
+import time
+from selenium import webdriver
+from selenium.webdriver.common.keys import Keys
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.common.by import By
+from selenium.common.exceptions import NoSuchElementException, UnexpectedAlertPresentException
+from selenium.webdriver.common.action_chains import ActionChains
+from bs4 import BeautifulSoup as soup
+import os
+
+# open chrome
+
+
+executable_path = "test/chromedriver"
+os.environ["webdriver.chrome.driver"] = executable_path
+
+chrome_options = Options()
+# need to add metamask or frame extension to options here to complete
+
+driver = webdriver.Chrome(
+    executable_path=executable_path, chrome_options=chrome_options)
+driver.get("http://localhost:3000/steps")
+driver.maximize_window()
+
+expert = WebDriverWait(driver, 7).until(
+    EC.presence_of_element_located(
+        (By.XPATH,  '//*[@id="__next"]/div/div/div/div/div/div[1]')))
+expert.click()
+
+time.sleep(.5)
+
+client = WebDriverWait(driver, 7).until(
+    EC.presence_of_element_located(
+        (By.XPATH,  '//*[@id="__next"]/div/div/div/div/div/div[2]')))
+client.click()
+
+time.sleep(.5)
+
+expert = WebDriverWait(driver, 7).until(
+    EC.presence_of_element_located(
+        (By.XPATH,  '//*[@id="__next"]/div/div/div/div/div/div[1]')))
+expert.click()
+
+continue_button = WebDriverWait(driver, 7).until(
+    EC.presence_of_element_located(
+        (By.XPATH,  '//*[@id="__next"]/div/div/div/div/div/div[1]/button')))
+continue_button.click()
+
+
+first_name = WebDriverWait(driver, 7).until(
+    EC.presence_of_element_located(
+        (By.XPATH,  "//input[@placeholder='First name']")))
+first_name.click()
+first_name.send_keys("firstName")
+
+last_name = driver.find_element_by_xpath("//input[@placeholder='Last name']")
+last_name.click()
+last_name.send_keys("lastName")
+
+display_name = driver.find_element_by_xpath(
+    "//input[@placeholder='choose your unique name']")
+display_name.click()
+display_name.send_keys("test1er")
+
+email = driver.find_element_by_xpath("//input[@placeholder='Email']")
+email.click()
+email.send_keys("test@twali.xyz")
+
+twitter = driver.find_element_by_xpath("//input[@placeholder='Twitter']")
+twitter.click()
+twitter.send_keys("https://twitter.com/vitalikButerin")
+
+linked_in = driver.find_element_by_xpath("//input[@placeholder='LinkedIn']")
+linked_in.click()
+linked_in.send_keys("https://linkedIn.com/")
+
+website = driver.find_element_by_xpath("//input[@placeholder='Website URL']")
+website.click()
+website.send_keys("https://twali.xyz/")
+
+time.sleep(1)
+
+continue_button_2 = driver.find_element_by_xpath(
+    '//*[@id="__next"]/div/div/div/div/div[2]/button[2]')
+continue_button_2.click()
+
+
+biz_type = WebDriverWait(driver, 7).until(
+    EC.presence_of_element_located(
+        (By.XPATH,  '//*[@id="business-type"]')))
+biz_type.click()
+biz_type.send_keys("i'")
+
+time.sleep(1)
+
+biz_type = WebDriverWait(driver, 7).until(
+    EC.presence_of_element_located(
+        (By.XPATH,  '//*[@id="business-type"]')))
+biz_type.click()
+biz_type.send_keys("s")
+biz_type.send_keys(Keys.ENTER)
+
+time.sleep(.5)
+
+biz_name = driver.find_element_by_xpath('//*[@id="business-name"]')
+biz_name.click()
+biz_name.send_keys("test")
+
+
+biz_name = driver.find_element_by_xpath('//*[@id="business-location"]')
+biz_name.click()
+biz_name.send_keys("un")
+biz_type.send_keys(Keys.ENTER)
+
+
+time.sleep(1)
+
+continue_button_3 = driver.find_element_by_xpath(
+    '//*[@id="__next"]/div/div/div/div/div[2]/button[2]')
+continue_button_3.click()
+
+
+current_title = WebDriverWait(driver, 7).until(
+    EC.presence_of_element_located(
+        (By.XPATH,  "//input[@placeholder='Current title']")))
+current_title.click()
+current_title.send_keys("test engineer")
+
+current_location = driver.find_element_by_xpath('//*[@id="current-location"]')
+current_location.click()
+current_location.send_keys("s")
+time.sleep(.2)
+current_location.send_keys(Keys.TAB)
+
+
+functional_expertise = driver.find_element_by_xpath(
+    '//*[@id="functional-Expertise"]')
+functional_expertise.click()
+functional_expertise.send_keys("c")
+functional_expertise.send_keys(Keys.TAB)
+
+
+industry = driver.find_element_by_xpath(
+    '//*[@id="industry-Expertise"]')
+industry.click()
+industry.send_keys("b")
+industry.send_keys(Keys.TAB)
+
+functional_expertise_add_button = driver.find_element_by_xpath(
+    '//*[@id="__next"]/div/div/div/div/form/div/div/h4/div[3]/button')
+functional_expertise_add_button.click()
+functional_expertise_add_button.click()
+
+
+industry_add_button = driver.find_element_by_xpath(
+    '//*[@id="__next"]/div/div/div/div/form/div/div/h4/div[4]/button')
+industry_add_button.click()
+industry_add_button.click()
+
+
+final_continue = driver.find_element_by_xpath(
+    '//*[@id="__next"]/div/div/div/div/div[2]/button[2]')
+final_continue.click()


### PR DESCRIPTION
### What changes were made?

- Implemented new onboarding flow from the [figma file](https://www.figma.com/file/x2RMgJNwAg4O7ExgJdni6A/Profile-Flow?node-id=193%3A2814)

### Is there any background info about the change?

- Added `customStepsTheme.ts` file for custom styling of the steps header from chakra-ui-steps
- Separated each step into its own file in sign up steps 

### Are there any state changes? Mention key ones (if any)

NA

### Screenshots or Gifs✨
<img width="1512" alt="Screen Shot 2022-03-22 at 6 37 47 PM" src="https://user-images.githubusercontent.com/24376928/159542109-d1ebee27-777d-48d9-9b7a-d3b0509fab8b.png">
<img width="1512" alt="Screen Shot 2022-03-22 at 6 37 54 PM" src="https://user-images.githubusercontent.com/24376928/159542107-4edfb573-6d06-4207-b41e-dd9a3d304754.png">
<img width="1512" alt="Screen Shot 2022-03-22 at 6 38 01 PM" src="https://user-images.githubusercontent.com/24376928/159542104-5ded9c6d-65e1-460e-a7b0-2c313e418e9b.png">
<img width="1512" alt="Screen Shot 2022-03-22 at 6 38 10 PM" src="https://user-images.githubusercontent.com/24376928/159542096-6860e395-e135-4617-868b-706e52ea7173.png">
<img width="1512" alt="Screen Shot 2022-03-22 at 6 38 19 PM" src="https://user-images.githubusercontent.com/24376928/159542088-f9e93bb4-c019-48be-ae39-8cd001fdf4c1.png">
<img width="1512" alt="Screen Shot 2022-03-22 at 6 38 30 PM" src="https://user-images.githubusercontent.com/24376928/159542066-ab70edd7-c15e-4828-854a-26d309eac518.png">







### Any new dependencies? Why were they added?

NA

### Shortcut Link

https://app.shortcut.com/twali/story/503/implement-new-design-for-sign-up-steps
