### PR TITLE
fix userState changing when visiting others profiles. Fix twitter URL…

### DIFF
--- a/components/HeaderNav/HeaderNav.tsx
+++ b/components/HeaderNav/HeaderNav.tsx
@@ -1,5 +1,5 @@
 import { Referral } from "./../reusable/Referral";
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import {
   Button,
   CircularProgress,
@@ -14,7 +14,7 @@ import {
   MenuItem,
 } from "@chakra-ui/react";
 import { useRouter } from "next/router";
-import { handleWalletConnect } from "../../utils/walletUtils";
+import { getUserByWallet, handleWalletConnect } from "../../utils/walletUtils";
 import Link from "next/link";
 import useUser from "../../context/TwaliContext";
 import { disconnect } from "@wagmi/core";
@@ -24,12 +24,18 @@ const HeaderNav = (props) => {
   const isConnectWalletBtn = props.isConnectWalletBtn;
   const setUserData = props.setUserData;
   const userPage = props.userPage;
-  const { userName } = useUser();
-  const userWallet = props.userWallet;
+  const { userName, userWallet } = useUser();
+
   const [isSubmitted, setIsSubmitted] = useState(false);
   const [loaded, setLoaded] = useState(false);
   const router = useRouter();
 
+  useEffect(() => {
+    props.userWallet &&
+      getUserByWallet(props.userWallet).then((user) => {
+        user && props.setUserData(user);
+      });
+  }, [userWallet]);
   return (
     <Flex
       height={"80px"}

--- a/components/Profile/ProfileData/ProfileSocialMedia.tsx
+++ b/components/Profile/ProfileData/ProfileSocialMedia.tsx
@@ -6,8 +6,8 @@ export function ProfileSocialMedia({ userData, ...props }) {
   const splitLinkedIn = userData.linkedIn
     ?.toLowerCase()
     .split(/(linkedin\.com)/);
-  const twitterUserName = userData.twitter.replace('@', '')
-  
+  const twitterUserName = userData.twitter.replace("@", "");
+
   return (
     <HStack width={"6rem"} {...props}>
       {userData.linkedIn && userData.linkedIn !== "undefined" && (
@@ -34,7 +34,7 @@ export function ProfileSocialMedia({ userData, ...props }) {
         <Link
           href={
             splitTwitter.length > 1
-              ? `https://www.twitter.com${
+              ? `https://www.twitter.com/${
                   splitTwitter[splitTwitter.indexOf("twitter.com") + 1]
                 }`
               : `https://www.twitter.com/${twitterUserName}`

--- a/components/Profile/ProfileDetails.tsx
+++ b/components/Profile/ProfileDetails.tsx
@@ -22,6 +22,7 @@ import HeaderNav from "../HeaderNav/HeaderNav";
 import { UserData } from "../../utils/interfaces";
 import { GetCompany } from "./GetCompany";
 import LoadingPage from "../../pages/loading";
+import useUser from "../../context/TwaliContext";
 
 const ProfileDetails = ({ user }) => {
   // Fallback for getStaticPaths, when fallback: true
@@ -31,6 +32,7 @@ const ProfileDetails = ({ user }) => {
   if (router.isFallback) {
     return <LoadingPage loaded={router.isFallback} />;
   }
+  const { setData } = useUser();
   const [userData, setUserData] = useState<UserData>();
 
   const {
@@ -270,6 +272,7 @@ const ProfileDetails = ({ user }) => {
               userPage={userData}
               userWallet={loggedInUserAddress}
               userName={userData.userName}
+              setUserData={setData}
             />
             <Container
               maxW="100%"


### PR DESCRIPTION
… if user only saved userName instead of full URL

### What changes were made?

- sets userData using wallet address if userState context is lost

### Is there any background info about the change?

- Prevents userState from changing to another users data/empty data

### Are there any state changes? Mention key ones (if any)

- setData in the headerNav using getUserByWallet()

### Screenshots or Gifs✨


### Any new dependencies? Why were they added?

na

### Shortcut Link

https://app.shortcut.com/twali/story/951/user-state-being-changed-when-visiting-other-user-profile