### PR TITLE
Prod button removal

### DIFF
--- a/context/TokenContext.tsx
+++ b/context/TokenContext.tsx
@@ -27,7 +27,7 @@ const TokenContext = ({ children }) => {
     const [token, setToken] = useState('Token');
     const [tokenIcon, setTokenIcon] = useState('');
     const [tokenID, setTokenID] = useState('');
-    console.log('context token:', token);
+    // console.log('context token:', token);
 
 
     useEffect(() => {

--- a/context/TokenContext.tsx
+++ b/context/TokenContext.tsx
@@ -27,7 +27,6 @@ const TokenContext = ({ children }) => {
     const [token, setToken] = useState('Token');
     const [tokenIcon, setTokenIcon] = useState('');
     const [tokenID, setTokenID] = useState('');
-    // console.log('context token:', token);
 
 
     useEffect(() => {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -241,7 +241,7 @@ const IndexPage = () => {
                   anything?
                 </Text>
               </HStack>
-              <Button
+              {/* <Button
                 width={["167px", "207px"]}
                 height={["48px", "52px"]}
                 color={"cave"}
@@ -259,14 +259,14 @@ const IndexPage = () => {
                 boxShadow={"0px 4px 4px 0px #00000040"}
               >
                 <Link
-                  href="https://airtable.com/shrjjPJnyesvqcSeB"
+                  href="/login"
                   isExternal
                   _hover={{ textDecor: "none" }}
                   _focus={{ textDecor: "none" }}
                 >
                   apply here
                 </Link>
-              </Button>
+              </Button> */}
             </Flex>
             <HStack>
               <Text

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -241,32 +241,7 @@ const IndexPage = () => {
                   anything?
                 </Text>
               </HStack>
-              {/* <Button
-                width={["167px", "207px"]}
-                height={["48px", "52px"]}
-                color={"cave"}
-                variant={"primary"}
-                fontSize={["18px", "24px"]}
-                borderRadius={"52px"}
-                padding={"8px 24px 4px"}
-                marginLeft={[
-                  "5px !important",
-                  "10px !important",
-                  "20px !important",
-                  "40px !important",
-                ]}
-                marginTop={["15px", "25px", "0"]}
-                boxShadow={"0px 4px 4px 0px #00000040"}
-              >
-                <Link
-                  href="/login"
-                  isExternal
-                  _hover={{ textDecor: "none" }}
-                  _focus={{ textDecor: "none" }}
-                >
-                  apply here
-                </Link>
-              </Button> */}
+
             </Flex>
             <HStack>
               <Text

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -27,7 +27,7 @@ const LoginPage = (props) => {
   const [loaded, setLoaded] = useState(false);
   const { ...userState } = useUser();
   const [referredBy, setReferredBy] = useState<string | string[]>();
-  console.log("ROUTER: ", router.query["referred_by"]);
+  // console.log("ROUTER: ", router.query["referred_by"]);
   useEffect(() => {
     setLoaded(!props.loaded);
     setReferredBy(router.query["referred_by"]);

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -27,7 +27,7 @@ const LoginPage = (props) => {
   const [loaded, setLoaded] = useState(false);
   const { ...userState } = useUser();
   const [referredBy, setReferredBy] = useState<string | string[]>();
-  // console.log("ROUTER: ", router.query["referred_by"]);
+
   useEffect(() => {
     setLoaded(!props.loaded);
     setReferredBy(router.query["referred_by"]);

--- a/serverless.yml
+++ b/serverless.yml
@@ -1,4 +1,4 @@
-twali-xyz-staging:
+twali-xyz-production:
   component: "@sls-next/serverless-component@3.7.0-alpha.11"
   inputs:
     roleArn: "arn:aws:iam::517934542124:role/deploy-dev"

--- a/serverless.yml
+++ b/serverless.yml
@@ -7,6 +7,5 @@ twali-xyz-staging:
         TABLE_NAME: "production_twali_core"
         WHITELIST_TABLE: "whitelist_table"
     cloudfront:
-      distributionId: EHZYCKLX3TYQ4 # for Staging env only, change for local testing
-    bucketName: qdlwzqy-k2v6lc # for Staging env only, change for local testing
-
+      distributionId: E1N063HBIE24ZH
+    bucketName: twali-production 


### PR DESCRIPTION
### What changes were made?

- `Apply Here` button removal as it doesn't reflect current user flow
- Removed a couple console.logs that were showing in production frontend console
- Updated Serverless file to reflect production format

### Is there any background info about the change?

- Just to not have Apply here redirect someone incorrectly

### Are there any state changes? Mention key ones (if any)

N/A
### Screenshots or Gifs✨

![Screen Shot 2022-07-28 at 12 20 35 PM](https://user-images.githubusercontent.com/48919838/181588388-b46d8222-e334-454a-a04e-50fe3e95ffbb.png)


### Any new dependencies? Why were they added?
- N/A
### Shortcut Link

https://app.shortcut.com/twali/story/1148/apply-here-landing-page-button-removal
